### PR TITLE
Fix PHP 8.4 property compatibility in ImportCommand and InitCommand

### DIFF
--- a/src/Command/ImportCommand.php
+++ b/src/Command/ImportCommand.php
@@ -19,9 +19,12 @@ class ImportCommand extends Command {
 	use ModelAwareTrait;
 
 	/**
-	 * @var string|null
+	 * @inheritDoc
 	 */
-	protected ?string $modelClass = 'TinyAuthBackend.AllowRules';
+	public function __construct() {
+		parent::__construct();
+		$this->modelClass = 'TinyAuthBackend.AllowRules';
+	}
 
 	/**
 	 * @inheritDoc

--- a/src/Command/ImportCommand.php
+++ b/src/Command/ImportCommand.php
@@ -6,7 +6,6 @@ use Cake\Console\Arguments;
 use Cake\Console\ConsoleIo;
 use Cake\Console\ConsoleOptionParser;
 use Cake\Core\Configure;
-use Cake\Datasource\ModelAwareTrait;
 use Shim\Command\Command;
 use TinyAuthBackend\Utility\AdapterConfig;
 use TinyAuthBackend\Utility\Importer;
@@ -16,15 +15,7 @@ use TinyAuthBackend\Utility\Importer;
  */
 class ImportCommand extends Command {
 
-	use ModelAwareTrait;
-
-	/**
-	 * @inheritDoc
-	 */
-	public function __construct() {
-		parent::__construct();
-		$this->modelClass = 'TinyAuthBackend.AllowRules';
-	}
+	protected string $defaultTable = 'TinyAuthBackend.AllowRules';
 
 	/**
 	 * @inheritDoc

--- a/src/Command/ImportCommand.php
+++ b/src/Command/ImportCommand.php
@@ -15,7 +15,7 @@ use TinyAuthBackend\Utility\Importer;
  */
 class ImportCommand extends Command {
 
-	protected string $defaultTable = 'TinyAuthBackend.AllowRules';
+	protected ?string $defaultTable = 'TinyAuthBackend.AllowRules';
 
 	/**
 	 * @inheritDoc

--- a/src/Command/InitCommand.php
+++ b/src/Command/InitCommand.php
@@ -19,9 +19,12 @@ class InitCommand extends Command {
 	use ModelAwareTrait;
 
 	/**
-	 * @var string|null
+	 * @inheritDoc
 	 */
-	protected ?string $modelClass = 'TinyAuthBackend.AllowRules';
+	public function __construct() {
+		parent::__construct();
+		$this->modelClass = 'TinyAuthBackend.AllowRules';
+	}
 
 	/**
 	 * @inheritDoc

--- a/src/Command/InitCommand.php
+++ b/src/Command/InitCommand.php
@@ -5,7 +5,6 @@ namespace TinyAuthBackend\Command;
 use Cake\Console\Arguments;
 use Cake\Console\ConsoleIo;
 use Cake\Console\ConsoleOptionParser;
-use Cake\Datasource\ModelAwareTrait;
 use Cake\Routing\Router;
 use Shim\Command\Command;
 use TinyAuth\Utility\TinyAuth;
@@ -16,15 +15,7 @@ use TinyAuthBackend\Utility\Importer;
  */
 class InitCommand extends Command {
 
-	use ModelAwareTrait;
-
-	/**
-	 * @inheritDoc
-	 */
-	public function __construct() {
-		parent::__construct();
-		$this->modelClass = 'TinyAuthBackend.AllowRules';
-	}
+	protected string $defaultTable = 'TinyAuthBackend.AllowRules';
 
 	/**
 	 * @inheritDoc

--- a/src/Command/InitCommand.php
+++ b/src/Command/InitCommand.php
@@ -15,7 +15,7 @@ use TinyAuthBackend\Utility\Importer;
  */
 class InitCommand extends Command {
 
-	protected string $defaultTable = 'TinyAuthBackend.AllowRules';
+	protected ?string $defaultTable = 'TinyAuthBackend.AllowRules';
 
 	/**
 	 * @inheritDoc


### PR DESCRIPTION
Fixes #10 

## Problem
Under PHP 8.4, the `$modelClass` property definition in `ImportCommand` and `InitCommand` conflicts with the same property in `ModelAwareTrait`, causing a fatal error:
> TinyAuthBackend\Command\ImportCommand and Cake\Datasource\ModelAwareTrait define the same property ($modelClass) in the composition of TinyAuthBackend\Command\ImportCommand. However, the definition differs and is considered incompatible.

## Solution
Moved the `$modelClass` initialization from the property declaration to the constructor in both files. This resolves the property compatibility issue while maintaining the same functionality.

## Changes
- `ImportCommand.php`: Initialize `$modelClass` in constructor instead of property declaration
- `InitCommand.php`: Initialize `$modelClass` in constructor instead of property declaration