### PR TITLE
Fix auth hierarchy semantics and document usage modes

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,4 +25,4 @@ composer require dereuromark/cakephp-tinyauth-backend
 It will auto-require `dereuromark/cakephp-tinyauth` dependency.
 
 ## Usage
-See [Docs](/docs).
+See [Docs](/docs/README.md).

--- a/config/Migrations/20260325000000_CreateTinyAuthTables.php
+++ b/config/Migrations/20260325000000_CreateTinyAuthTables.php
@@ -86,7 +86,7 @@ class CreateTinyAuthTables extends BaseMigration {
 			->addColumn('table_name', 'string', ['limit' => 100, 'null' => false])
 			->addColumn('created', 'datetime', ['null' => true])
 			->addColumn('modified', 'datetime', ['null' => true])
-			->addIndex(['name'], ['unique' => true])
+			->addIndex(['entity_class'], ['unique' => true])
 			->create();
 
 		// Resource Abilities table

--- a/config/bootstrap.php
+++ b/config/bootstrap.php
@@ -11,6 +11,7 @@ Configure::write('TinyAuthBackend', [
 	'rolesTable' => 'roles', // Multi-role: pivot table
 	'cacheEnabled' => true,
 	'cacheConfig' => 'default',
+	'superAdminRole' => null,
 
 	// Feature toggles (hybrid: auto-detect from DB tables, override here)
 	// null = auto-detect, true = force enable, false = force disable

--- a/config/bootstrap.php
+++ b/config/bootstrap.php
@@ -8,7 +8,7 @@ Configure::write('TinyAuthBackend', [
 	'roleHierarchy' => true,
 	'multiRole' => false, // Set true for users with multiple roles
 	'roleColumn' => 'role_id', // Single role: column name
-	'rolesTable' => 'roles', // Multi-role: pivot table
+	'rolesTable' => 'roles', // Multi-role: loaded association/property name on the user entity
 	'cacheEnabled' => true,
 	'cacheConfig' => 'default',
 	'superAdminRole' => null,

--- a/docs/AdapterOnly.md
+++ b/docs/AdapterOnly.md
@@ -1,0 +1,79 @@
+## Adapter-Only Strategy
+
+Use this mode if you want to keep the classic TinyAuth runtime behavior and only replace the old INI files with database-backed adapters.
+
+This is the closest match to "what `allow` and `acl` already did before, just from DB".
+
+### What You Keep
+
+- TinyAuth remains your runtime authorization layer
+- `DbAllowAdapter` replaces `allow.ini`
+- `DbAclAdapter` replaces `acl.ini`
+- the backend UI becomes the place where those rules are edited
+
+### What You Do Not Need
+
+- `TinyAuthPolicy`
+- CakePHP Authorization integration
+- resources/scopes if you do not want entity-level permissions
+
+### Minimal Config
+
+```php
+'TinyAuth' => [
+    'allowAdapter' => \TinyAuthBackend\Auth\AllowAdapter\DbAllowAdapter::class,
+    'aclAdapter' => \TinyAuthBackend\Auth\AclAdapter\DbAclAdapter::class,
+],
+'TinyAuthBackend' => [
+    'features' => [
+        'allow' => true,
+        'acl' => true,
+        'roles' => true,
+        'resources' => false,
+        'scopes' => false,
+    ],
+],
+```
+
+### Recommended Flow
+
+1. Run the plugin migrations.
+2. Sync controllers/actions into the backend.
+3. Import your old INI files once if you are migrating existing rules.
+4. Point TinyAuth to the DB adapters.
+5. Manage `allow` and `acl` from `/admin/auth`.
+
+### Import Existing INI Files
+
+```bash
+bin/cake tiny_auth_backend import allow
+bin/cake tiny_auth_backend import acl
+```
+
+Or initialize only the backend entry permissions for an admin role:
+
+```bash
+bin/cake tiny_auth_backend init admin
+```
+
+### What Tables Matter In This Mode
+
+- `tinyauth_roles`
+- `tinyauth_controllers`
+- `tinyauth_actions`
+- `tinyauth_acl_permissions`
+
+You can ignore:
+
+- `tinyauth_resources`
+- `tinyauth_resource_abilities`
+- `tinyauth_scopes`
+- `tinyauth_resource_acl`
+
+### Good Fit
+
+Choose this mode if:
+
+- you already use TinyAuth today
+- you do not want to redesign your permission model
+- you only want to move rule storage and editing into the database/backend UI

--- a/docs/Authentication.md
+++ b/docs/Authentication.md
@@ -1,23 +1,53 @@
-## Backend: Authentication
+## Authentication And Public Actions
 
-This is for "allow" management.
+This section is about the backend's **Allow** feature: actions that should be reachable without authentication.
 
-### Schema
-The tables currently expect the following fields:
-- type (`AllowRule::TYPE_ALLOW`, `AllowRule::TYPE_DENY`)
-- path (`VendorName/PluginName.Prefix/ControllerName::actionName`)
+### What It Controls
 
-### Important info
-`deny` always trumps `allow` rules for the same path.
+The normalized backend stores public action flags in:
 
-### Prefix casing
-In TinyAuth and for CakePHP 3+ routing params multi-word prefixes are supposed to be dashed.
-For a nested prefix for `\App\MyPrefix\MySubPrefix\MyTestController` controller class,
-it would be `my-prefix/my-sub-prefix`.
-For path syntax however, it is the namespace elements, thus `MyPrefix/MySubPrefix`.
+- `tinyauth_controllers`
+- `tinyauth_actions`
 
-For BC reasons and usability it will auto-inflect when saving.
-So both cases are accepted as input.
+An action is public when `tinyauth_actions.is_public = true`.
 
-### TODO
-Check if we can make a more normalized DB structure and a better UI selection for defining the rules.
+### Runtime Use
+
+If you use TinyAuth at runtime, point it to the DB allow adapter:
+
+```php
+'TinyAuth' => [
+    'allowAdapter' => \TinyAuthBackend\Auth\AllowAdapter\DbAllowAdapter::class,
+],
+```
+
+`DbAllowAdapter` reads public actions from the database and feeds them into TinyAuth's request-level allow logic.
+
+### Backend UI
+
+Manage public actions at:
+
+```text
+/admin/auth/allow
+```
+
+You can:
+
+- toggle individual actions
+- bulk-toggle all actions for one controller
+- sync controllers/actions from code first, then mark public endpoints in the UI
+
+### Migration From Legacy INI
+
+If you used TinyAuth's file-based allow rules before, import them once:
+
+```bash
+bin/cake tiny_auth_backend import allow
+```
+
+### Important Note
+
+This doc is only about **public request access**.
+
+For role-based controller/action ACL use [Acl.md](Acl.md).
+For entity/resource authorization use [Resources.md](Resources.md).

--- a/docs/Authorization.md
+++ b/docs/Authorization.md
@@ -1,229 +1,104 @@
 ## Authorization Integration
 
-TinyAuthBackend integrates with `cakephp/authorization` for comprehensive permission management.
+Use this mode if you want TinyAuthBackend to drive **entity/resource authorization** with CakePHP's `cakephp/authorization` plugin.
 
-### Overview
+### What This Package Provides
 
-The plugin provides `TinyAuthPolicy` which checks permissions against the database-backed ACL.
+- `TinyAuthPolicy` for entity-level checks
+- `TinyAuthService` for direct permission lookups
+- backend UIs for resources, scopes, roles, and rule management
+
+### What It Does Not Provide Automatically
+
+`TinyAuthPolicy` is **not** a request policy for controller/action routing.
+
+Use one of these approaches:
+
+- keep TinyAuth `allow`/`acl` for controller/action access and use Authorization for entities
+- write your own request policy if you want request authorization fully inside CakePHP Authorization
 
 ### Setup
 
-#### 1. Install cakephp/authorization
+Install Authorization:
 
 ```bash
 composer require cakephp/authorization
 ```
 
-#### 2. Load the Plugin
+Load the plugin and middleware in your app as usual.
+
+### Mapping `TinyAuthPolicy`
+
+Map it as the default policy for entities you want to control from the backend:
 
 ```php
-// In src/Application.php bootstrap()
-$this->addPlugin('Authorization');
-```
-
-#### 3. Add Middleware
-
-```php
-// In src/Application.php middleware()
-public function middleware(MiddlewareQueue $middlewareQueue): MiddlewareQueue
-{
-    $middlewareQueue
-        // ... other middleware
-        ->add(new AuthenticationMiddleware($this))
-        ->add(new AuthorizationMiddleware($this));
-
-    return $middlewareQueue;
-}
-```
-
-#### 4. Configure Authorization Service
-
-```php
-// In src/Application.php
 use Authorization\AuthorizationService;
 use Authorization\AuthorizationServiceInterface;
 use Authorization\AuthorizationServiceProviderInterface;
-use Authorization\Policy\MapResolver;
+use Authorization\Policy\OrmResolver;
 use Psr\Http\Message\ServerRequestInterface;
 use TinyAuthBackend\Policy\TinyAuthPolicy;
 
-class Application extends BaseApplication implements
-    AuthorizationServiceProviderInterface
+class Application extends BaseApplication implements AuthorizationServiceProviderInterface
 {
     public function getAuthorizationService(
         ServerRequestInterface $request
     ): AuthorizationServiceInterface {
-        $resolver = new MapResolver();
-
-        // Use TinyAuthPolicy for request authorization
-        $resolver->map(ServerRequest::class, TinyAuthPolicy::class);
+        $resolver = new OrmResolver(TinyAuthPolicy::class);
 
         return new AuthorizationService($resolver);
     }
 }
 ```
 
-### Using TinyAuthPolicy
-
-The `TinyAuthPolicy` automatically checks ACL permissions:
+### In Controllers
 
 ```php
-// In a controller
-public function edit($id)
-{
-    // This checks if the current user has 'edit' permission
-    // for this controller via the TinyAuthPolicy
-    $this->Authorization->authorize($this->request);
-
-    // ... rest of action
-}
-```
-
-### Custom Policies
-
-For entity-level authorization, create custom policies:
-
-```php
-// src/Policy/ArticlePolicy.php
-namespace App\Policy;
-
-use App\Model\Entity\Article;
-use Authorization\IdentityInterface;
-use TinyAuthBackend\Service\TinyAuthService;
-
-class ArticlePolicy
-{
-    protected TinyAuthService $tinyAuth;
-
-    public function __construct()
-    {
-        $this->tinyAuth = new TinyAuthService();
-    }
-
-    /**
-     * Check if user can view an article
-     */
-    public function canView(IdentityInterface $user, Article $article): bool
-    {
-        // Use resource-based permissions
-        return $this->tinyAuth->canAccessResource($user, $article, 'view');
-    }
-
-    /**
-     * Check if user can edit an article
-     */
-    public function canEdit(IdentityInterface $user, Article $article): bool
-    {
-        return $this->tinyAuth->canAccessResource($user, $article, 'edit');
-    }
-
-    /**
-     * Check if user can delete an article
-     */
-    public function canDelete(IdentityInterface $user, Article $article): bool
-    {
-        return $this->tinyAuth->canAccessResource($user, $article, 'delete');
-    }
-}
-```
-
-Register the policy:
-
-```php
-// In Application::getAuthorizationService()
-$resolver->map(Article::class, ArticlePolicy::class);
-```
-
-### Controller Authorization
-
-Use authorization in controllers:
-
-```php
-// Authorize the request (checks TinyAuthPolicy)
-$this->Authorization->authorize($this->request);
-
-// Authorize an entity
 $article = $this->Articles->get($id);
 $this->Authorization->authorize($article, 'edit');
-
-// Skip authorization for an action
-$this->Authorization->skipAuthorization();
 ```
 
-### Combining ACL and Resource Permissions
-
-You can use both controller-level ACL and entity-level resource permissions:
+### In Views
 
 ```php
-public function edit($id)
-{
-    // 1. Check if user can access this controller/action (ACL)
-    $this->Authorization->authorize($this->request);
-
-    // 2. Check if user can edit this specific article (Resource)
-    $article = $this->Articles->get($id);
-    $this->Authorization->authorize($article, 'edit');
-
-    // ... edit logic
-}
-```
-
-### Middleware Configuration
-
-The authorization middleware can be configured:
-
-```php
-$middlewareQueue->add(new AuthorizationMiddleware($this, [
-    // Redirect unauthorized users
-    'unauthorizedHandler' => [
-        'className' => 'Authorization.Redirect',
-        'url' => '/users/login',
-        'queryParam' => 'redirect',
-    ],
-]));
-```
-
-### Component Configuration
-
-Load the Authorization component in your AppController:
-
-```php
-// In AppController::initialize()
-public function initialize(): void
-{
-    parent::initialize();
-
-    $this->loadComponent('Authorization.Authorization');
-}
-```
-
-### Checking Permissions in Views
-
-```php
-// In a template
 <?php if ($this->Identity->can('edit', $article)): ?>
     <?= $this->Html->link('Edit', ['action' => 'edit', $article->id]) ?>
 <?php endif; ?>
 ```
 
-### SuperAdmin Bypass
+### Super Admin Bypass
 
-Configure a superadmin role that bypasses all checks:
+`TinyAuthPolicy` supports a configurable bypass role:
 
 ```php
-// In config/app.php
-'TinyAuth' => [
-    'superAdminRole' => 'superadmin',  // Role name
-    // or
-    'superAdminRole' => 99,  // Role ID
+'TinyAuthBackend' => [
+    'superAdminRole' => 'root',
 ],
 ```
 
-### Best Practices
+For backward compatibility it also reads `TinyAuth.superAdminRole`.
 
-1. **Use request authorization** for controller/action access
-2. **Use entity authorization** for entity-level access
-3. **Keep policies focused** - one policy per entity
-4. **Use TinyAuthService** for complex permission checks
-5. **Cache permissions** - they're cached automatically
-6. **Test authorization** - write tests for your policies
+If no config is set, the built-in fallback aliases are:
+
+- `admin`
+- `superadmin`
+
+### Using `TinyAuthService` Directly
+
+```php
+use TinyAuthBackend\Service\TinyAuthService;
+
+$service = new TinyAuthService();
+
+$canEdit = $service->canAccessResource($user, $article, 'edit');
+$canCreate = $service->canPerformAbility($user, 'Article', 'create');
+$scope = $service->getScopeCondition($service->getUserRoles($user), 'Article', 'view', $user);
+```
+
+### Recommended Split
+
+A practical setup is:
+
+1. TinyAuth `allow` and `acl` handle controller/action entry.
+2. Authorization policies handle entity-level checks.
+3. TinyAuthBackend stores both in one admin backend.

--- a/docs/NativeAuth.md
+++ b/docs/NativeAuth.md
@@ -1,0 +1,82 @@
+## Native CakePHP Auth Strategy
+
+Use this mode if you want CakePHP Authentication/Authorization to stay in charge at runtime and you do **not** want TinyAuth to handle request authorization.
+
+### Important Constraint
+
+This package still depends on `dereuromark/cakephp-tinyauth` at install time.
+
+That does **not** mean you must use TinyAuth as your runtime auth layer.
+
+You can instead use TinyAuthBackend mainly for:
+
+- role management
+- resource/ability editing
+- scope management
+- permission administration UI
+
+and consume that data from your own CakePHP Authorization policies/services.
+
+### Practical Split
+
+- Authentication: `cakephp/authentication`
+- Authorization: `cakephp/authorization`
+- Permission storage/admin UI: `TinyAuthBackend`
+
+### Recommended Usage
+
+Use the backend's resource tables and `TinyAuthService` inside your policies:
+
+```php
+use App\Model\Entity\Article;
+use Cake\Datasource\EntityInterface;
+use TinyAuthBackend\Policy\TinyAuthPolicy;
+
+class ArticlePolicy extends TinyAuthPolicy
+{
+    public function canEdit(EntityInterface $user, Article $article): bool
+    {
+        return $this->can($user, 'edit', $article);
+    }
+}
+```
+
+Or call the service directly:
+
+```php
+use TinyAuthBackend\Service\TinyAuthService;
+
+$service = new TinyAuthService();
+$allowed = $service->canAccessResource($user, $article, 'edit');
+```
+
+### What To Avoid In This Mode
+
+If you are not using TinyAuth at runtime, do not wire up:
+
+- `DbAllowAdapter`
+- `DbAclAdapter`
+
+Those adapters are specifically for TinyAuth's controller/action flow.
+
+### Suggested Feature Set
+
+```php
+'TinyAuthBackend' => [
+    'features' => [
+        'allow' => false,
+        'acl' => false,
+        'roles' => true,
+        'resources' => true,
+        'scopes' => true,
+    ],
+],
+```
+
+### Good Fit
+
+Choose this mode if:
+
+- your app already uses CakePHP Authorization policies
+- you want a permission admin UI but not TinyAuth's runtime model
+- you mainly care about entity/resource authorization

--- a/docs/README.md
+++ b/docs/README.md
@@ -30,13 +30,16 @@ Common sections:
 
 ### Which Guide Should I Read?
 
-- [Adapter-Only Strategy](AdapterOnly.md)
+- [Strategies Overview](Strategies/README.md)
+- [Adapter-Only Strategy](Strategies/AdapterOnly.md)
+- [Full TinyAuthBackend Strategy](Strategies/FullBackend.md)
+- [Native CakePHP Auth Strategy](Strategies/NativeAuth.md)
+- [External Role Source Strategy](Strategies/ExternalRoles.md)
 - [Authorization Integration](Authorization.md)
 - [Resource Permissions](Resources.md)
 - [Roles and Hierarchy](Roles.md)
 - [Scopes](Scopes.md)
 - [Services API](Services.md)
-- [Native CakePHP Auth Strategy](NativeAuth.md)
 
 ### Feature Flags
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,138 +1,57 @@
 ## TinyAuth Backend
 
-A database-backed administration interface for TinyAuth with a modern, responsive UI.
+TinyAuthBackend gives you a database-backed admin UI for permissions and roles.
 
-### Features
+The package supports three practical usage modes:
 
-- **Normalized Database Schema**: 8 tables for roles, controllers, actions, permissions, resources, and scopes
-- **Tree+Matrix UI**: Controller tree navigation with permission matrix view
-- **Role Hierarchy**: Drag-and-drop role ordering with parent/child relationships
-- **HTMX+Alpine.js Frontend**: Reactive UI with minimal JavaScript
-- **Standalone Layout**: Self-contained with Tailwind CSS (CDN), dark/light theme support
-- **Authorization Integration**: TinyAuthPolicy for cakephp/authorization
-- **DB Adapters**: DbAllowAdapter and DbAclAdapter for TinyAuth integration
-- **Controller Sync**: Auto-discovery of controllers and actions from the application
+1. **Adapter-only TinyAuth**: keep classic TinyAuth `allow` + `acl` behavior, but store those rules in the database instead of INI files.
+2. **Full TinyAuthBackend**: use the admin UI plus resources, scopes, role hierarchy, and `TinyAuthPolicy`/`TinyAuthService` for entity authorization.
+3. **Backend UI + native CakePHP auth**: keep CakePHP Authentication/Authorization as your runtime layer and use this package mainly as a DB-backed permission management UI.
 
-### Enable the Plugin
+### Admin URL
 
-```bash
-bin/cake plugin load TinyAuthBackend
+The plugin mounts under:
+
+```text
+/admin/auth
 ```
 
-### Run Migrations
-
-Create the required database tables:
-
-```bash
-bin/cake migrations migrate -p TinyAuthBackend
-```
-
-This creates the following tables:
-
-| Table | Purpose |
-|-------|---------|
-| `tinyauth_roles` | User roles with hierarchy support |
-| `tinyauth_controllers` | Discovered controllers (plugin/prefix/name) |
-| `tinyauth_actions` | Controller actions with public flag |
-| `tinyauth_acl_permissions` | Role-to-action permission mappings |
-| `tinyauth_resources` | Entity resources for resource-based auth |
-| `tinyauth_resource_abilities` | Resource abilities (view, edit, delete, etc.) |
-| `tinyauth_scopes` | Reusable permission conditions |
-| `tinyauth_resource_acl` | Resource-to-role permission mappings |
-
-### Enable the Adapters
-
-Configure TinyAuth to use the database adapters:
-
-```php
-// In config/app.php or config/app_local.php
-'TinyAuth' => [
-    'allowAdapter' => \TinyAuthBackend\Auth\AllowAdapter\DbAllowAdapter::class,
-    'aclAdapter' => \TinyAuthBackend\Auth\AclAdapter\DbAclAdapter::class,
-],
-```
-
-### Initialize Roles
-
-Add your application's roles to the database:
-
-```bash
-bin/cake tiny_auth_backend init {admin-role-name}
-```
-
-Or configure roles in `config/roles.php`:
-
-```php
-<?php
-return [
-    'Roles' => [
-        'user' => 1,
-        'moderator' => 2,
-        'admin' => 3,
-    ],
-];
-```
-
-### Admin Panel
-
-Navigate to the admin panel:
-
-```
-/admin/tinyauth/admin/
-```
-
-#### Available Sections
+Common sections:
 
 | URL | Purpose |
 |-----|---------|
-| `/admin/tinyauth/admin/acl` | ACL permission matrix (main view) |
-| `/admin/tinyauth/admin/allow` | Public action management |
-| `/admin/tinyauth/admin/roles` | Role management with hierarchy |
-| `/admin/tinyauth/admin/resources` | Resource-based permissions |
-| `/admin/tinyauth/admin/scopes` | Reusable permission scopes |
-| `/admin/tinyauth/admin/sync` | Sync controllers from application |
+| `/admin/auth/allow` | Public action management |
+| `/admin/auth/acl` | Controller/action ACL matrix |
+| `/admin/auth/roles` | Roles and hierarchy |
+| `/admin/auth/resources` | Resource abilities |
+| `/admin/auth/scopes` | Field-based scopes |
+| `/admin/auth/sync/controllers` | Scan controllers/actions into DB |
+| `/admin/auth/sync/resources` | Scan entities/resources into DB |
 
-### Import from INI Files
+### Which Guide Should I Read?
 
-If migrating from file-based TinyAuth:
+- [Adapter-Only Strategy](AdapterOnly.md)
+- [Authorization Integration](Authorization.md)
+- [Resource Permissions](Resources.md)
+- [Roles and Hierarchy](Roles.md)
+- [Scopes](Scopes.md)
+- [Services API](Services.md)
+- [Native CakePHP Auth Strategy](NativeAuth.md)
 
-```bash
-# Import allow rules
-bin/cake tiny_auth_backend import allow
+### Feature Flags
 
-# Import ACL rules
-bin/cake tiny_auth_backend import acl
-
-# Import from specific file
-bin/cake tiny_auth_backend import acl /path/to/file.ini
-```
-
-### Detailed Documentation
-
-- [ACL Management](Acl.md) - Permission matrix and role-based access
-- [Allow Management](Allow.md) - Public action configuration
-- [Roles](Roles.md) - Role hierarchy and management
-- [Resources](Resources.md) - Entity-level permissions
-- [Scopes](Scopes.md) - Conditional permission rules
-- [Services](Services.md) - Programmatic API
-- [Authorization](Authorization.md) - cakephp/authorization integration
-
-### Caching
-
-Permissions are cached automatically. Clear the cache after manual database changes:
+You can force-enable or disable parts of the backend with `TinyAuthBackend.features`:
 
 ```php
-use Cake\Cache\Cache;
-
-Cache::delete('TinyAuth.allow');
-Cache::delete('TinyAuth.acl');
+'TinyAuthBackend' => [
+    'features' => [
+        'allow' => true,
+        'acl' => true,
+        'roles' => true,
+        'resources' => false,
+        'scopes' => false,
+    ],
+],
 ```
 
-### Custom Theme
-
-You can override templates by creating them in your app:
-
-```
-templates/plugin/TinyAuthBackend/Admin/Acl/index.php
-templates/plugin/TinyAuthBackend/layout/tinyauth.php
-```
+This is useful when you only want the classic TinyAuth adapter functionality exposed in the UI.

--- a/docs/Resources.md
+++ b/docs/Resources.md
@@ -1,182 +1,120 @@
 ## Resource-Based Permissions
 
-Resources enable entity-level permissions (e.g., "user can edit their own posts").
+Resources are the entity-level part of the backend.
 
-### Overview
+They answer questions like:
 
-While ACL manages controller/action permissions, Resources manage entity-level access:
+- "Can this user edit this article?"
+- "Can moderators delete comments?"
+- "Can users edit only their own records?"
 
-- **ACL**: "Can user access the Articles edit action?"
-- **Resources**: "Can user edit THIS specific article?"
+### Data Model
 
-### Concepts
+- **Resource**: entity type, for example `Article`
+- **Ability**: action on that resource, for example `view`, `edit`, `publish`
+- **Scope**: optional field match, for example `article.user_id === user.id`
 
-| Term | Description |
-|------|-------------|
-| Resource | An entity type (e.g., Article, Comment) |
-| Ability | An action on a resource (e.g., view, edit, delete) |
-| Scope | A condition that limits access (e.g., "own" items only) |
+### Syncing Resources
 
-### Setting Up Resources
+The backend can scan your entities and register them as resources:
 
-#### 1. Add a Resource
+```bash
+bin/cake migrations migrate -p TinyAuthBackend
+```
 
-1. Go to `/admin/tinyauth/admin/resources`
-2. Click "Add Resource"
-3. Enter:
-   - **Name**: Display name (e.g., "Article")
-   - **Entity Class**: Full class name (e.g., `App\Model\Entity\Article`)
-   - **Table Name**: Database table (e.g., `articles`)
+Then use the sync UI at:
 
-#### 2. Add Abilities
+```text
+/admin/auth/sync/resources
+```
 
-For each resource, define what users can do:
+Or call `ResourceSyncService` directly.
 
-1. Click "Manage Abilities" on the resource
-2. Add abilities like:
-   - `view` - Read access
-   - `edit` - Modify access
-   - `delete` - Remove access
-   - `publish` - Custom ability
+Synced resource names use the entity class basename, for example:
 
-#### 3. Assign Permissions
+- `App\Model\Entity\Article` -> `Article`
+- `Blog\Model\Entity\Post` -> `Post`
 
-On the Resources page, set permissions per role:
-
-| Role | Ability | Scope |
-|------|---------|-------|
-| user | view | (none) - can view all |
-| user | edit | own - can edit own only |
-| moderator | edit | (none) - can edit all |
-| admin | delete | (none) - can delete all |
-
-### Database Schema
+### Example Schema
 
 ```sql
--- Resources
 CREATE TABLE tinyauth_resources (
     id INT AUTO_INCREMENT PRIMARY KEY,
     name VARCHAR(100) NOT NULL UNIQUE,
     entity_class VARCHAR(200) NOT NULL,
-    table_name VARCHAR(100) NOT NULL,
-    created DATETIME,
-    modified DATETIME
+    table_name VARCHAR(100) NOT NULL
 );
 
--- Abilities per resource
 CREATE TABLE tinyauth_resource_abilities (
     id INT AUTO_INCREMENT PRIMARY KEY,
     resource_id INT NOT NULL,
-    name VARCHAR(50) NOT NULL,
-    description VARCHAR(200),
-    created DATETIME,
-    modified DATETIME,
-    FOREIGN KEY (resource_id) REFERENCES tinyauth_resources(id)
+    name VARCHAR(50) NOT NULL
 );
 
--- Resource ACL permissions
 CREATE TABLE tinyauth_resource_acl (
     id INT AUTO_INCREMENT PRIMARY KEY,
-    ability_id INT NOT NULL,
+    resource_ability_id INT NOT NULL,
     role_id INT NOT NULL,
-    scope_id INT NULL,
-    type ENUM('allow', 'deny') NOT NULL,
-    created DATETIME,
-    modified DATETIME,
-    FOREIGN KEY (ability_id) REFERENCES tinyauth_resource_abilities(id),
-    FOREIGN KEY (role_id) REFERENCES tinyauth_roles(id),
-    FOREIGN KEY (scope_id) REFERENCES tinyauth_scopes(id)
+    type VARCHAR(10) NOT NULL,
+    scope_id INT NULL
 );
 ```
 
-### Using in Policies
+### Policy Example
 
 ```php
-// src/Policy/ArticlePolicy.php
 namespace App\Policy;
 
 use App\Model\Entity\Article;
-use Authorization\IdentityInterface;
-use TinyAuthBackend\Service\TinyAuthService;
+use Cake\Datasource\EntityInterface;
+use TinyAuthBackend\Policy\TinyAuthPolicy;
 
-class ArticlePolicy
+class ArticlePolicy extends TinyAuthPolicy
 {
-    protected TinyAuthService $tinyAuth;
-
-    public function __construct()
+    public function canPublish(EntityInterface $user, Article $article): bool
     {
-        $this->tinyAuth = new TinyAuthService();
-    }
-
-    public function canView(IdentityInterface $user, Article $article): bool
-    {
-        return $this->tinyAuth->canAccessResource($user, $article, 'view');
-    }
-
-    public function canEdit(IdentityInterface $user, Article $article): bool
-    {
-        return $this->tinyAuth->canAccessResource($user, $article, 'edit');
-    }
-
-    public function canDelete(IdentityInterface $user, Article $article): bool
-    {
-        return $this->tinyAuth->canAccessResource($user, $article, 'delete');
+        return $this->can($user, 'publish', $article);
     }
 }
 ```
 
-### Programmatic API
+Or use `TinyAuthPolicy` as the default ORM policy if your rules are fully backend-driven.
+
+### Direct Service Example
 
 ```php
 use TinyAuthBackend\Service\TinyAuthService;
 
 $service = new TinyAuthService();
 
-// Check resource access
 $canEdit = $service->canAccessResource($user, $article, 'edit');
-
-// Get all abilities user has for a resource
-$abilities = $service->getResourceAbilities($user, $article);
-// Returns: ['view', 'edit']
-
-// Check ability without entity (type-level)
 $canCreate = $service->canPerformAbility($user, 'Article', 'create');
 ```
 
-### Common Patterns
+### Scope Example
 
-#### Owner-Only Access
+If a scope named `own` uses:
 
-```php
-// Scope: own
-// entity_field: user_id
-// user_field: id
+- `entity_field = user_id`
+- `user_field = id`
 
-// This allows users to edit only articles where:
-// $article->user_id === $user->id
-```
+then this backend rule:
 
-#### Team-Based Access
+- role `user`
+- resource `Article`
+- ability `edit`
+- scope `own`
 
-```php
-// Scope: team
-// entity_field: team_id
-// user_field: team_id
-
-// This allows users to edit articles in their team:
-// $article->team_id === $user->team_id
-```
-
-#### Status-Based Access
-
-For more complex conditions, use custom scopes or policy logic:
+means:
 
 ```php
-public function canPublish(IdentityInterface $user, Article $article): bool
-{
-    // Must have ability AND article must be in draft status
-    $hasAbility = $this->tinyAuth->canAccessResource($user, $article, 'publish');
-
-    return $hasAbility && $article->status === 'draft';
-}
+$article->user_id === $user->id
 ```
+
+### Interaction With Role Hierarchy
+
+If role hierarchy is enabled:
+
+- higher roles inherit lower-role resource permissions
+- a direct rule on the current role wins over inherited rules
+- inherited scoped rules also flow into `getScopeCondition()`

--- a/docs/Roles.md
+++ b/docs/Roles.md
@@ -45,7 +45,7 @@ You do not have to manage roles in `tinyauth_roles`.
 When an external source is used:
 
 - the roles UI becomes read-only
-- the backend still uses those aliases for ACL/resource assignments
+- external roles are mirrored into `tinyauth_roles` so ACL/resource assignments can still be stored with foreign keys
 
 ### Example Config
 

--- a/docs/Roles.md
+++ b/docs/Roles.md
@@ -1,138 +1,60 @@
 ## Role Management
 
-The Roles page manages user roles with support for hierarchy and ordering.
+The roles section manages aliases, ordering, and optional hierarchy.
 
-### Overview
+### Role Fields
 
-Roles define permission levels in your application. The hierarchy determines which permissions are inherited.
+| Field | Meaning |
+|-------|---------|
+| `name` | Human-readable label |
+| `alias` | Runtime role key used by permission checks |
+| `sort_order` | Display/order hint |
+| `parent_id` | Higher role that this role rolls up into |
 
-### Role Properties
+### Hierarchy Semantics
 
-| Field | Description |
-|-------|-------------|
-| `name` | Internal role identifier (e.g., `admin`) |
-| `alias` | Display name (e.g., `Administrator`) |
-| `sort_order` | Hierarchy level (higher = more privileges) |
-| `parent_id` | Optional parent role for inheritance |
+This plugin models hierarchy like this:
 
-### Role Hierarchy
-
-Roles can form a hierarchy where higher roles inherit permissions from lower roles:
-
-```
-admin (sort_order: 3)
-  └── moderator (sort_order: 2)
-        └── user (sort_order: 1)
+```text
+admin
+  └─ moderator
+      └─ user
 ```
 
-In this example:
-- Admin has all permissions of moderator and user
-- Moderator has all permissions of user
-- User has only their own permissions
+Meaning:
 
-### Managing Roles
+- `user.parent_id = moderator`
+- `moderator.parent_id = admin`
+- higher roles inherit lower-role permissions
 
-#### Add a Role
+So if `user` can `edit Article`, then `moderator` and `admin` also inherit that permission unless they have a direct rule of their own.
 
-1. Click "Add Role"
-2. Enter name, alias, and sort order
-3. Optionally select a parent role
-4. Save
+Direct rules win over inherited ones.
 
-#### Edit a Role
+### External Role Sources
 
-1. Click the edit icon next to the role
-2. Modify fields
-3. Save
+You do not have to manage roles in `tinyauth_roles`.
 
-#### Reorder Roles
+`TinyAuthBackend.roleSource` can be:
 
-Drag and drop roles to change their hierarchy order. Higher positions = higher privileges.
+- `null`: use the plugin table
+- a Configure path string
+- an array of `alias => id`
+- a callable returning that array
 
-#### Delete a Role
+When an external source is used:
 
-1. Click the delete icon
-2. Confirm deletion
+- the roles UI becomes read-only
+- the backend still uses those aliases for ACL/resource assignments
 
-**Warning**: Deleting a role removes all associated permissions.
-
-### Database Schema
-
-```sql
-CREATE TABLE tinyauth_roles (
-    id INT AUTO_INCREMENT PRIMARY KEY,
-    name VARCHAR(50) NOT NULL UNIQUE,
-    alias VARCHAR(100),
-    sort_order INT DEFAULT 0,
-    parent_id INT NULL,
-    created DATETIME,
-    modified DATETIME,
-    FOREIGN KEY (parent_id) REFERENCES tinyauth_roles(id)
-);
-```
-
-### Configuration Integration
-
-Roles should match your application's role configuration:
+### Example Config
 
 ```php
-// config/roles.php
-return [
-    'Roles' => [
-        'user' => 1,       // Maps to tinyauth_roles where name='user'
-        'moderator' => 2,  // Maps to tinyauth_roles where name='moderator'
-        'admin' => 3,      // Maps to tinyauth_roles where name='admin'
+'TinyAuthBackend' => [
+    'roleSource' => [
+        'user' => 1,
+        'moderator' => 2,
+        'admin' => 3,
     ],
-];
+],
 ```
-
-The numeric values are role IDs that match the database.
-
-### Programmatic Access
-
-```php
-use TinyAuthBackend\Service\HierarchyService;
-
-$service = new HierarchyService();
-
-// Get all roles a user can access (including inherited)
-$effectiveRoles = $service->getEffectiveRoles($userRoleId);
-
-// Get role hierarchy
-$hierarchy = $service->getHierarchy();
-
-// Check if role is above another
-$isHigher = $service->isRoleAbove($roleA, $roleB);
-```
-
-### Syncing Roles
-
-To sync roles from your configuration:
-
-```php
-$rolesTable = $this->fetchTable('TinyAuthBackend.Roles');
-$configRoles = Configure::read('Roles');
-
-foreach ($configRoles as $name => $id) {
-    $existing = $rolesTable->find()
-        ->where(['name' => $name])
-        ->first();
-
-    if (!$existing) {
-        $role = $rolesTable->newEntity([
-            'name' => $name,
-            'alias' => ucfirst($name),
-            'sort_order' => $id,
-        ]);
-        $rolesTable->save($role);
-    }
-}
-```
-
-### Best Practices
-
-1. **Use descriptive names**: `content_editor` instead of `role2`
-2. **Set meaningful aliases**: Display names for the UI
-3. **Plan hierarchy carefully**: Higher roles inherit lower role permissions
-4. **Document role purposes**: Keep track of what each role is for
-5. **Limit role count**: Too many roles become hard to manage

--- a/docs/Scopes.md
+++ b/docs/Scopes.md
@@ -15,7 +15,7 @@ entity.{entity_field} === user.{user_field}
 
 ### Creating Scopes
 
-1. Go to `/admin/tinyauth/admin/scopes`
+1. Go to `/admin/auth/scopes`
 2. Click "Add Scope"
 3. Enter:
    - **Name**: Identifier (e.g., `own`, `team`, `department`)

--- a/docs/Services.md
+++ b/docs/Services.md
@@ -1,10 +1,10 @@
 ## Services
 
-The plugin provides several services for programmatic access to permissions.
+These services are the stable programmatic surface of the plugin.
 
 ### TinyAuthService
 
-Central service for permission checking.
+Use `TinyAuthService` for resource-level permission checks.
 
 ```php
 use TinyAuthBackend\Service\TinyAuthService;
@@ -12,41 +12,43 @@ use TinyAuthBackend\Service\TinyAuthService;
 $service = new TinyAuthService();
 ```
 
-#### Methods
+Available methods:
 
 ```php
-// Check if action is public (no auth required)
-$isPublic = $service->isPublicAction(
-    string $controller,
-    string $action,
-    array $options = []  // ['plugin' => '', 'prefix' => '']
-): bool;
+// Low-level role-based check
+$allowed = $service->canAccess(
+    ['admin', 'moderator'],
+    'Article',
+    'edit',
+    $article,
+    $user
+);
 
-// Check if user has ACL access to an action
-$hasAccess = $service->hasAccess(
-    IdentityInterface $user,
-    string $controller,
-    string $action,
-    array $options = []
-): bool;
+// Convenience wrapper for entity checks
+$allowed = $service->canAccessResource($user, $article, 'edit');
 
-// Check if user can access a resource with an ability
-$canAccess = $service->canAccessResource(
-    IdentityInterface $user,
-    EntityInterface $entity,
-    string $ability
-): bool;
+// Type-level check without an entity instance
+$allowed = $service->canPerformAbility($user, 'Article', 'create');
 
-// Get all abilities user has for a resource
-$abilities = $service->getResourceAbilities(
-    IdentityInterface $user,
-    EntityInterface $entity
-): array;
+// Resolve the exact DB rule for one role/resource/ability triple
+$rule = $service->getResourcePermission('admin', 'Article', 'edit');
+
+// Build ORM conditions from a scoped permission
+$conditions = $service->getScopeCondition(['admin'], 'Article', 'view', $user);
+
+// Resolve the caller's role aliases from config/DB
+$roles = $service->getUserRoles($user);
 ```
+
+`getScopeCondition()` returns:
+
+- `null` for no access
+- `[]` for unrestricted access
+- an array of conditions for scoped access
 
 ### HierarchyService
 
-Manages role hierarchy traversal.
+Use `HierarchyService` when you need to inspect or apply role hierarchy.
 
 ```php
 use TinyAuthBackend\Service\HierarchyService;
@@ -54,181 +56,99 @@ use TinyAuthBackend\Service\HierarchyService;
 $service = new HierarchyService();
 ```
 
-#### Methods
+Available methods:
 
 ```php
-// Get all roles user can access (including inherited)
-$roles = $service->getEffectiveRoles(int $roleId): array;
+// Parent chain, nearest parent first
+$parents = $service->getParentRoles('user');
 
-// Get complete role hierarchy
-$hierarchy = $service->getHierarchy(): array;
+// All descendants as alias => id
+$children = $service->getChildRoles('admin', $availableRoles);
 
-// Check if roleA is above roleB in hierarchy
-$isAbove = $service->isRoleAbove(int $roleA, int $roleB): bool;
+// Descendant aliases ordered from nearest child to deepest node
+$descendants = $service->getDescendantRoleAliases('admin');
 
-// Get parent roles for a role
-$parents = $service->getParentRoles(int $roleId): array;
-
-// Get child roles for a role
-$children = $service->getChildRoles(int $roleId): array;
+// Expand TinyAuth ACL data so higher roles inherit lower-role allows
+$acl = $service->applyInheritance($acl, $availableRoles);
 ```
+
+Hierarchy semantics in this plugin are:
+
+- `parent_id` points from a lower role to a higher role
+- higher roles inherit lower-role permissions
+- direct rules on the current role win over inherited rules
 
 ### ControllerSyncService
 
-Syncs controllers and actions from the application.
+Scans controllers/actions and stores them in the backend tables.
 
 ```php
 use TinyAuthBackend\Service\ControllerSyncService;
 
 $service = new ControllerSyncService();
+$result = $service->sync();
+$controllers = $service->scan();
 ```
 
-#### Methods
+`sync()` returns:
 
 ```php
-// Sync all controllers and actions
-$result = $service->sync(): array;
-// Returns: ['added' => 5, 'updated' => 2, 'removed' => 1]
-
-// Get all discovered controllers
-$controllers = $service->discoverControllers(): array;
-
-// Get actions for a controller class
-$actions = $service->discoverActions(string $controllerClass): array;
+['added' => 0, 'updated' => 0, 'actions_added' => 0]
 ```
 
 ### ResourceSyncService
 
-Syncs entity resources from the application.
+Scans entities and stores them as resources.
 
 ```php
 use TinyAuthBackend\Service\ResourceSyncService;
 
 $service = new ResourceSyncService();
+$result = $service->sync();
+$resources = $service->scan();
 ```
 
-#### Methods
+By default, synced resources get these abilities:
 
 ```php
-// Sync all entity resources
-$result = $service->sync(): array;
-
-// Discover entity classes
-$entities = $service->discoverEntities(): array;
+['view', 'create', 'edit', 'delete']
 ```
 
-### ImportExportService
-
-Handles import/export of permissions.
+You can override them:
 
 ```php
-use TinyAuthBackend\Service\ImportExportService;
-
-$service = new ImportExportService();
-```
-
-#### Methods
-
-```php
-// Export all permissions as JSON
-$json = $service->exportAsJson(): string;
-
-// Export ACL permissions as CSV
-$csv = $service->exportAclAsCsv(): string;
-
-// Export allow rules as CSV
-$csv = $service->exportAllowAsCsv(): string;
-
-// Import from JSON
-$result = $service->importFromJson(string $json): array;
-// Returns: ['imported' => 50, 'errors' => []]
-
-// Import from legacy INI format
-$result = $service->importFromIni(string $content, string $type): array;
-// $type: 'allow' or 'acl'
+$service->setDefaultAbilities(['view', 'publish']);
 ```
 
 ### FeatureService
 
-Manages feature flags for the plugin.
+Determines which backend sections are enabled.
 
 ```php
 use TinyAuthBackend\Service\FeatureService;
 
 $service = new FeatureService();
+$enabled = $service->isEnabled('resources');
+$items = $service->getNavigationItems();
 ```
 
-#### Methods
+Known feature keys:
 
-```php
-// Check if a feature is enabled
-$enabled = $service->isEnabled(string $feature): bool;
-
-// Available features:
-// - 'resources' - Resource-based permissions
-// - 'scopes' - Conditional permissions
-// - 'hierarchy' - Role hierarchy
-// - 'sync' - Auto-sync controllers
-```
+- `allow`
+- `acl`
+- `roles`
+- `resources`
+- `scopes`
 
 ### RoleSourceService
 
-Provides role data from configuration or database.
+Resolves roles from the database or an external config/callback source.
 
 ```php
 use TinyAuthBackend\Service\RoleSourceService;
 
 $service = new RoleSourceService();
-```
-
-#### Methods
-
-```php
-// Get all roles (merged from config and DB)
-$roles = $service->getRoles(): array;
-
-// Get role by ID
-$role = $service->getRole(int $id): ?array;
-
-// Get role by name
-$role = $service->getRoleByName(string $name): ?array;
-```
-
-### Service Registration
-
-Services can be registered in your application's container:
-
-```php
-// In src/Application.php
-public function services(ContainerInterface $container): void
-{
-    $container->add(TinyAuthService::class);
-    $container->add(HierarchyService::class);
-    // etc.
-}
-```
-
-Then inject via constructor:
-
-```php
-class ArticlePolicy
-{
-    public function __construct(
-        protected TinyAuthService $tinyAuth
-    ) {}
-}
-```
-
-### Caching
-
-Services automatically use caching. To clear:
-
-```php
-use Cake\Cache\Cache;
-
-// Clear all TinyAuth caches
-Cache::delete('TinyAuth.allow');
-Cache::delete('TinyAuth.acl');
-Cache::delete('TinyAuth.roles');
-Cache::delete('TinyAuth.hierarchy');
+$roles = $service->getRoles();
+$entities = $service->getRoleEntities();
+$managed = $service->isManaged();
 ```

--- a/docs/Strategies/AdapterOnly.md
+++ b/docs/Strategies/AdapterOnly.md
@@ -50,7 +50,7 @@ bin/cake tiny_auth_backend import allow
 bin/cake tiny_auth_backend import acl
 ```
 
-Or initialize only the backend entry permissions for an admin role:
+Or initialize backend access for an admin role:
 
 ```bash
 bin/cake tiny_auth_backend init admin
@@ -69,11 +69,3 @@ You can ignore:
 - `tinyauth_resource_abilities`
 - `tinyauth_scopes`
 - `tinyauth_resource_acl`
-
-### Good Fit
-
-Choose this mode if:
-
-- you already use TinyAuth today
-- you do not want to redesign your permission model
-- you only want to move rule storage and editing into the database/backend UI

--- a/docs/Strategies/ExternalRoles.md
+++ b/docs/Strategies/ExternalRoles.md
@@ -1,0 +1,41 @@
+## External Role Source Strategy
+
+Use this mode if role aliases and IDs already live outside TinyAuthBackend, for example in:
+
+- app config
+- a custom role service
+- another table managed by your app
+
+### Config
+
+```php
+'TinyAuthBackend' => [
+    'roleSource' => 'Roles',
+],
+```
+
+Or:
+
+```php
+'TinyAuthBackend' => [
+    'roleSource' => [
+        'user' => 1,
+        'moderator' => 2,
+        'admin' => 3,
+    ],
+],
+```
+
+### How It Works
+
+- `RoleSourceService` reads aliases and IDs from the configured source
+- the roles page becomes read-only
+- external roles are mirrored into `tinyauth_roles` so ACL/resource permission rows can still use foreign keys safely
+
+### Good Fit
+
+Choose this mode if:
+
+- your app already owns role definitions elsewhere
+- you still want to manage ACL/resource assignments in TinyAuthBackend
+- you do not want admins changing role identity data from this plugin

--- a/docs/Strategies/FullBackend.md
+++ b/docs/Strategies/FullBackend.md
@@ -1,0 +1,45 @@
+## Full TinyAuthBackend Strategy
+
+Use this mode if you want the backend to be the main source of truth for:
+
+- controller/action access
+- public actions
+- roles and hierarchy
+- resource abilities
+- scoped entity permissions
+
+### Typical Stack
+
+- TinyAuth for request-level `allow` and `acl`
+- TinyAuthBackend for administration and storage
+- CakePHP Authorization for entity/resource checks
+
+### Recommended Feature Set
+
+```php
+'TinyAuthBackend' => [
+    'features' => [
+        'allow' => true,
+        'acl' => true,
+        'roles' => true,
+        'resources' => true,
+        'scopes' => true,
+    ],
+],
+```
+
+### Recommended Flow
+
+1. Migrate the plugin tables.
+2. Configure TinyAuth DB adapters.
+3. Sync controllers and resources.
+4. Set up `TinyAuthPolicy` or custom policies for your entities.
+5. Manage request and resource permissions from the same backend.
+
+### Good Fit
+
+Choose this mode if:
+
+- you want one admin backend for both request and entity authorization
+- you use role hierarchy
+- you need scoped permissions like "own records only"

--- a/docs/Strategies/NativeAuth.md
+++ b/docs/Strategies/NativeAuth.md
@@ -72,11 +72,3 @@ Those adapters are specifically for TinyAuth's controller/action flow.
     ],
 ],
 ```
-
-### Good Fit
-
-Choose this mode if:
-
-- your app already uses CakePHP Authorization policies
-- you want a permission admin UI but not TinyAuth's runtime model
-- you mainly care about entity/resource authorization

--- a/docs/Strategies/README.md
+++ b/docs/Strategies/README.md
@@ -1,0 +1,14 @@
+## Strategies
+
+These guides describe the supported ways to use TinyAuthBackend in a real app.
+
+### Available Strategies
+
+- [Adapter-Only TinyAuth](AdapterOnly.md)
+  Keep classic TinyAuth `allow`/`acl` behavior and move rule storage from INI files to database-backed adapters.
+- [Full TinyAuthBackend](FullBackend.md)
+  Use the full backend: roles, ACL, resources, scopes, hierarchy, and CakePHP Authorization integration.
+- [Native CakePHP Auth](NativeAuth.md)
+  Keep CakePHP Authentication/Authorization as the runtime layer and use TinyAuthBackend mainly as a permission admin UI.
+- [External Role Source](ExternalRoles.md)
+  Read roles from app config or a callback while keeping backend-managed ACL/resource assignments usable.

--- a/src/Command/ImportCommand.php
+++ b/src/Command/ImportCommand.php
@@ -25,10 +25,10 @@ class ImportCommand extends Command {
 		$type = $args->getArgument('type');
 		$file = $args->getArgument('file');
 		if (!$type || $type === 'allow') {
-			$this->importAllow($file);
+			$this->importAllow($file, $io);
 		}
 		if (!$type || $type === 'acl') {
-			$this->importAcl($file);
+			$this->importAcl($file, $io);
 		}
 
 		return static::CODE_SUCCESS;
@@ -56,12 +56,12 @@ class ImportCommand extends Command {
 
 	/**
 	 * @param string|null $file
-	 *
+	 * @param \Cake\Console\ConsoleIo $io
 	 * @return void
 	 */
-	protected function importAllow(?string $file): void {
+	protected function importAllow(?string $file, ConsoleIo $io): void {
 		if (!AdapterConfig::isAllowEnabled()) {
-			$this->io->error('Allow not enabled, skipping');
+			$io->error('Allow not enabled, skipping');
 
 			return;
 		}
@@ -74,7 +74,7 @@ class ImportCommand extends Command {
 			$file = $path . $fileName;
 		}
 		if (!file_exists($file)) {
-			$this->io->error($fileName . ' does not exist or cannot be found, skipping');
+			$io->error($fileName . ' does not exist or cannot be found, skipping');
 
 			return;
 		}
@@ -82,17 +82,17 @@ class ImportCommand extends Command {
 		$importer = new Importer();
 		$importer->importAllow($file);
 
-		$this->io->success('Imported: ' . $fileName);
+		$io->success('Imported: ' . $fileName);
 	}
 
 	/**
 	 * @param string|null $file
-	 *
+	 * @param \Cake\Console\ConsoleIo $io
 	 * @return void
 	 */
-	protected function importAcl(?string $file): void {
+	protected function importAcl(?string $file, ConsoleIo $io): void {
 		if (!AdapterConfig::isAclEnabled()) {
-			$this->io->error('ACL not enabled, skipping');
+			$io->error('ACL not enabled, skipping');
 
 			return;
 		}
@@ -105,7 +105,7 @@ class ImportCommand extends Command {
 			$file = $path . $fileName;
 		}
 		if (!file_exists($file)) {
-			$this->io->error($fileName . ' does not exist or cannot be found, skipping');
+			$io->error($fileName . ' does not exist or cannot be found, skipping');
 
 			return;
 		}
@@ -113,7 +113,7 @@ class ImportCommand extends Command {
 		$importer = new Importer();
 		$importer->importAcl($file);
 
-		$this->io->success('Imported: ' . $fileName);
+		$io->success('Imported: ' . $fileName);
 	}
 
 }

--- a/src/Command/InitCommand.php
+++ b/src/Command/InitCommand.php
@@ -25,15 +25,15 @@ class InitCommand extends Command {
 		$role = $args->getArgument('role');
 		$availableRoles = $this->_getAvailableRoles();
 		if (!in_array($role, $availableRoles, true)) {
-			$this->io->abort('Role ' . $role . ' does not seem to exist. Available: ' . implode(', ', $availableRoles));
+			$io->abort('Role ' . $role . ' does not seem to exist. Available: ' . implode(', ', $availableRoles));
 		}
 
 		$importer = new Importer();
 		$importer->initializeAcl($role);
 
-		$url = Router::url(['plugin' => 'TinyAuthBackend', 'prefix' => 'Admin', 'controller' => 'Auth', 'action' => 'index'], true);
+		$url = Router::url(['plugin' => 'TinyAuthBackend', 'prefix' => 'Admin', 'controller' => 'Dashboard', 'action' => 'index'], true);
 
-		$this->io->success('Necessary ACL rules stored. Using a user with this `' . $role . '` role you can now navigate to the backend `' . $url . '`.');
+		$io->success('Necessary ACL rules stored. Using a user with this `' . $role . '` role you can now navigate to the backend `' . $url . '`.');
 
 		return static::CODE_SUCCESS;
 	}

--- a/src/Controller/Admin/AclController.php
+++ b/src/Controller/Admin/AclController.php
@@ -5,6 +5,7 @@ namespace TinyAuthBackend\Controller\Admin;
 
 use Cake\Http\Exception\BadRequestException;
 use Cake\Http\Response;
+use TinyAuthBackend\Service\RoleSourceService;
 
 /**
  * @property \TinyAuthBackend\Model\Table\TinyauthControllersTable $TinyauthControllers
@@ -17,10 +18,10 @@ class AclController extends AppController {
 	public function index(): void {
 		/** @var \TinyAuthBackend\Model\Table\TinyauthControllersTable $controllersTable */
 		$controllersTable = $this->fetchTable('TinyAuthBackend.TinyauthControllers');
-		$rolesTable = $this->fetchTable('TinyAuthBackend.Roles');
+		$roleSource = new RoleSourceService();
 
 		$tree = $controllersTable->findTree();
-		$roles = $rolesTable->find()->orderBy(['sort_order' => 'ASC'])->all()->toArray();
+		$roles = $roleSource->getRoleEntities();
 
 		// Get selected controller
 		$controllerId = $this->request->getQuery('controller_id');
@@ -63,6 +64,9 @@ class AclController extends AppController {
 
 		if (!in_array($type, ['none', 'allow', 'deny'], true)) {
 			throw new BadRequestException('Invalid permission type');
+		}
+		if (!in_array($roleId, array_values((new RoleSourceService())->getRoles()), true)) {
+			throw new BadRequestException('Invalid role');
 		}
 
 		$permissionsTable = $this->fetchTable('TinyAuthBackend.AclPermissions');
@@ -119,7 +123,6 @@ class AclController extends AppController {
 		if (strlen($q) >= 2) {
 			$controllersTable = $this->fetchTable('TinyAuthBackend.TinyauthControllers');
 			$actionsTable = $this->fetchTable('TinyAuthBackend.Actions');
-			$rolesTable = $this->fetchTable('TinyAuthBackend.Roles');
 
 			$results['controllers'] = $controllersTable->find()
 				->where(['name LIKE' => "%{$q}%"])
@@ -134,11 +137,13 @@ class AclController extends AppController {
 				->all()
 				->toArray();
 
-			$results['roles'] = $rolesTable->find()
-				->where(['OR' => ['name LIKE' => "%{$q}%", 'alias LIKE' => "%{$q}%"]])
-				->limit(5)
-				->all()
-				->toArray();
+			$roles = (new RoleSourceService())->getRoleEntities();
+			$results['roles'] = array_slice(array_values(array_filter($roles, function (object $role) use ($q): bool {
+				$name = (string)($role->name ?? '');
+				$alias = (string)($role->alias ?? '');
+
+				return stripos($name, $q) !== false || stripos($alias, $q) !== false;
+			})), 0, 5);
 		}
 
 		$this->set('results', $results);

--- a/src/Controller/Admin/DashboardController.php
+++ b/src/Controller/Admin/DashboardController.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 namespace TinyAuthBackend\Controller\Admin;
 
 use TinyAuthBackend\Service\FeatureService;
+use TinyAuthBackend\Service\RoleSourceService;
 
 class DashboardController extends AppController {
 
@@ -14,14 +15,14 @@ class DashboardController extends AppController {
 		// Gather statistics
 		$controllersTable = $this->fetchTable('TinyAuthBackend.TinyauthControllers');
 		$actionsTable = $this->fetchTable('TinyAuthBackend.Actions');
-		$rolesTable = $this->fetchTable('TinyAuthBackend.Roles');
 		$aclPermissionsTable = $this->fetchTable('TinyAuthBackend.AclPermissions');
+		$roleSource = new RoleSourceService();
 
 		$stats = [
 			'controllers' => $controllersTable->find()->count(),
 			'actions' => $actionsTable->find()->count(),
 			'public_actions' => $actionsTable->find()->where(['is_public' => true])->count(),
-			'roles' => $rolesTable->find()->count(),
+			'roles' => count($roleSource->getRoles()),
 			'acl_permissions' => $aclPermissionsTable->find()->count(),
 		];
 

--- a/src/Controller/Admin/ResourcesController.php
+++ b/src/Controller/Admin/ResourcesController.php
@@ -5,6 +5,7 @@ namespace TinyAuthBackend\Controller\Admin;
 
 use Cake\Http\Exception\BadRequestException;
 use Cake\Http\Response;
+use TinyAuthBackend\Service\RoleSourceService;
 
 class ResourcesController extends AppController {
 
@@ -13,7 +14,6 @@ class ResourcesController extends AppController {
 	 */
 	public function index(): void {
 		$resourcesTable = $this->fetchTable('TinyAuthBackend.Resources');
-		$rolesTable = $this->fetchTable('TinyAuthBackend.Roles');
 		$scopesTable = $this->fetchTable('TinyAuthBackend.Scopes');
 
 		$query = $resourcesTable->find()
@@ -28,7 +28,7 @@ class ResourcesController extends AppController {
 
 		$resources = $query->all()->toArray();
 
-		$roles = $rolesTable->find()->orderBy(['sort_order' => 'ASC'])->all()->toArray();
+		$roles = (new RoleSourceService())->getRoleEntities();
 		$scopes = $scopesTable->find()->orderBy(['name' => 'ASC'])->all()->toArray();
 
 		// Get selected resource
@@ -80,6 +80,9 @@ class ResourcesController extends AppController {
 		// Validate type
 		if (!in_array($type, ['none', 'allow', 'deny'], true)) {
 			throw new BadRequestException('Invalid permission type');
+		}
+		if (!in_array($roleId, array_values((new RoleSourceService())->getRoles()), true)) {
+			throw new BadRequestException('Invalid role');
 		}
 
 		// Validate scope exists if provided

--- a/src/Controller/Admin/ResourcesController.php
+++ b/src/Controller/Admin/ResourcesController.php
@@ -3,6 +3,7 @@ declare(strict_types=1);
 
 namespace TinyAuthBackend\Controller\Admin;
 
+use Cake\Core\Configure;
 use Cake\Http\Exception\BadRequestException;
 use Cake\Http\Response;
 use TinyAuthBackend\Service\RoleSourceService;
@@ -18,10 +19,10 @@ class ResourcesController extends AppController {
 
 		$query = $resourcesTable->find()
 			->contain(['ResourceAbilities'])
-			->orderBy(['name' => 'ASC']);
+			->orderBy(['name' => 'ASC', 'entity_class' => 'ASC']);
 
 		// Filter to App namespace by default (configurable)
-		$namespaceFilter = \Cake\Core\Configure::read('TinyAuthBackend.resourceNamespaceFilter') ?? 'App\\';
+		$namespaceFilter = Configure::read('TinyAuthBackend.resourceNamespaceFilter') ?? 'App\\';
 		if ($namespaceFilter) {
 			$query->where(['entity_class LIKE' => $namespaceFilter . '%']);
 		}

--- a/src/Model/Table/ResourcesTable.php
+++ b/src/Model/Table/ResourcesTable.php
@@ -51,14 +51,14 @@ class ResourcesTable extends Table {
 			->scalar('name')
 			->maxLength('name', 100)
 			->requirePresence('name', 'create')
-			->notEmptyString('name')
-			->add('name', 'unique', ['rule' => 'validateUnique', 'provider' => 'table']);
+			->notEmptyString('name');
 
 		$validator
 			->scalar('entity_class')
 			->maxLength('entity_class', 200)
 			->requirePresence('entity_class', 'create')
-			->notEmptyString('entity_class');
+			->notEmptyString('entity_class')
+			->add('entity_class', 'unique', ['rule' => 'validateUnique', 'provider' => 'table']);
 
 		$validator
 			->scalar('table_name')

--- a/src/Model/Table/TinyauthControllersTable.php
+++ b/src/Model/Table/TinyauthControllersTable.php
@@ -3,6 +3,7 @@ declare(strict_types=1);
 
 namespace TinyAuthBackend\Model\Table;
 
+use Cake\Core\Configure;
 use Cake\ORM\Table;
 use Cake\Validation\Validator;
 
@@ -76,7 +77,7 @@ class TinyauthControllersTable extends Table {
 			->orderBy(['plugin' => 'ASC', 'prefix' => 'ASC', 'name' => 'ASC']);
 
 		// Filter out excluded plugins (default: DebugKit, TinyAuthBackend)
-		$excludedPlugins = \Cake\Core\Configure::read('TinyAuthBackend.excludedPlugins') ?? ['DebugKit'];
+		$excludedPlugins = Configure::read('TinyAuthBackend.excludedPlugins') ?? ['DebugKit'];
 		if ($excludedPlugins) {
 			$query->where([
 				'OR' => [

--- a/src/Policy/TinyAuthPolicy.php
+++ b/src/Policy/TinyAuthPolicy.php
@@ -169,11 +169,7 @@ class TinyAuthPolicy implements BeforePolicyInterface {
 	 * @return string The resource name.
 	 */
 	protected function getResourceName(EntityInterface $entity): string {
-		$className = get_class($entity);
-		$parts = explode('\\', $className);
-		$entityName = end($parts) ?: '';
-
-		return $entityName;
+		return get_class($entity);
 	}
 
 	/**

--- a/src/Policy/TinyAuthPolicy.php
+++ b/src/Policy/TinyAuthPolicy.php
@@ -6,8 +6,8 @@ namespace TinyAuthBackend\Policy;
 use Authorization\IdentityInterface;
 use Authorization\Policy\BeforePolicyInterface;
 use BadMethodCallException;
+use Cake\Core\Configure;
 use Cake\Datasource\EntityInterface;
-use Cake\Utility\Inflector;
 use TinyAuthBackend\Service\TinyAuthService;
 
 /**
@@ -60,8 +60,8 @@ class TinyAuthPolicy implements BeforePolicyInterface {
 		// Get user roles
 		$roles = $this->tinyAuth->getUserRoles($user);
 
-		// Super admin bypass (optional - can be configured)
-		if (in_array('admin', $roles, true) || in_array('superadmin', $roles, true)) {
+		// Super admin bypass
+		if (array_intersect($roles, $this->getSuperAdminRoles())) {
 			return true;
 		}
 
@@ -171,9 +171,28 @@ class TinyAuthPolicy implements BeforePolicyInterface {
 	protected function getResourceName(EntityInterface $entity): string {
 		$className = get_class($entity);
 		$parts = explode('\\', $className);
-		$entityName = end($parts);
+		$entityName = end($parts) ?: '';
 
-		return Inflector::pluralize($entityName);
+		return $entityName;
+	}
+
+	/**
+	 * @return array<string>
+	 */
+	protected function getSuperAdminRoles(): array {
+		$superAdminRole = Configure::read('TinyAuthBackend.superAdminRole');
+		if ($superAdminRole === null) {
+			$superAdminRole = Configure::read('TinyAuth.superAdminRole');
+		}
+
+		if (is_string($superAdminRole) && $superAdminRole !== '') {
+			return [$superAdminRole];
+		}
+		if (is_array($superAdminRole)) {
+			return array_values(array_filter($superAdminRole, 'is_string'));
+		}
+
+		return ['admin', 'superadmin'];
 	}
 
 	/**

--- a/src/Service/HierarchyService.php
+++ b/src/Service/HierarchyService.php
@@ -79,8 +79,10 @@ class HierarchyService {
 
 		$parents = [];
 		$currentAlias = $roleAlias;
+		$visited = [];
 
-		while (isset($this->roleParents[$currentAlias])) {
+		while (isset($this->roleParents[$currentAlias]) && !isset($visited[$currentAlias])) {
+			$visited[$currentAlias] = true;
 			$parentAlias = $this->roleParents[$currentAlias];
 			$parents[] = $parentAlias;
 			$currentAlias = $parentAlias;
@@ -106,15 +108,19 @@ class HierarchyService {
 
 			foreach ($controllerAcl['allow'] as $action => $roles) {
 				foreach ($roles as $roleAlias => $roleId) {
-					// Get all child roles that should inherit this permission
-					$childRoles = $this->getChildRoles($roleAlias, $availableRoles);
-					foreach ($childRoles as $childAlias => $childId) {
+					// Higher roles inherit lower-role permissions.
+					$parentRoles = $this->getParentRoles($roleAlias);
+					foreach ($parentRoles as $parentAlias) {
+						$parentId = $availableRoles[$parentAlias] ?? null;
+						if ($parentId === null) {
+							continue;
+						}
 						// Don't override explicit deny
-						if (isset($acl[$key]['deny'][$action][$childAlias])) {
+						if (isset($acl[$key]['deny'][$action][$parentAlias])) {
 							continue;
 						}
 						// Add inherited permission
-						$acl[$key]['allow'][$action][$childAlias] = $childId;
+						$acl[$key]['allow'][$action][$parentAlias] = $parentId;
 					}
 				}
 			}
@@ -148,15 +154,43 @@ class HierarchyService {
 	}
 
 	/**
+	 * Get descendant role aliases ordered from nearest child to deepest descendant.
+	 *
+	 * @param string $parentAlias The parent role alias.
+	 * @return array<string>
+	 */
+	public function getDescendantRoleAliases(string $parentAlias): array {
+		$this->ensureHierarchyLoaded();
+
+		$rolesTable = TableRegistry::getTableLocator()->get('TinyAuthBackend.Roles');
+		/** @var \TinyAuthBackend\Model\Entity\Role|null $parent */
+		$parent = $rolesTable->find()->where(['alias' => $parentAlias])->first();
+		if (!$parent) {
+			return [];
+		}
+
+		$aliases = [];
+		$this->collectDescendantAliases($parent->id, $aliases, $rolesTable);
+
+		return $aliases;
+	}
+
+	/**
 	 * Recursively collect child roles.
 	 *
 	 * @param int $parentId The parent role ID.
 	 * @param array<string, int> $children Reference to children array to populate.
 	 * @param array<string, int> $availableRoles Available roles as alias => id mapping.
 	 * @param \Cake\ORM\Table $rolesTable The roles table instance.
+	 * @param array<int, bool> $visited
 	 * @return void
 	 */
-	protected function collectChildren(int $parentId, array &$children, array $availableRoles, Table $rolesTable): void {
+	protected function collectChildren(int $parentId, array &$children, array $availableRoles, Table $rolesTable, array &$visited = []): void {
+		if (isset($visited[$parentId])) {
+			return;
+		}
+		$visited[$parentId] = true;
+
 		$childRoles = $rolesTable->find()->where(['parent_id' => $parentId])->all();
 
 		/** @var \TinyAuthBackend\Model\Entity\Role $child */
@@ -164,7 +198,34 @@ class HierarchyService {
 			if (isset($availableRoles[$child->alias])) {
 				$children[$child->alias] = $availableRoles[$child->alias];
 			}
-			$this->collectChildren($child->id, $children, $availableRoles, $rolesTable);
+			$this->collectChildren($child->id, $children, $availableRoles, $rolesTable, $visited);
+		}
+	}
+
+	/**
+	 * @param int $parentId
+	 * @param array<string> $aliases
+	 * @param \Cake\ORM\Table $rolesTable
+	 * @param array<int, bool> $visited
+	 * @return void
+	 */
+	protected function collectDescendantAliases(int $parentId, array &$aliases, Table $rolesTable, array &$visited = []): void {
+		if (isset($visited[$parentId])) {
+			return;
+		}
+		$visited[$parentId] = true;
+
+		$childRoles = $rolesTable->find()
+			->select(['id', 'alias'])
+			->where(['parent_id' => $parentId])
+			->orderByAsc('sort_order')
+			->orderByAsc('id')
+			->all();
+
+		/** @var \TinyAuthBackend\Model\Entity\Role $child */
+		foreach ($childRoles as $child) {
+			$aliases[] = $child->alias;
+			$this->collectDescendantAliases($child->id, $aliases, $rolesTable, $visited);
 		}
 	}
 

--- a/src/Service/ResourceSyncService.php
+++ b/src/Service/ResourceSyncService.php
@@ -100,7 +100,7 @@ class ResourceSyncService {
 		$scanned = $this->scan();
 		$result = ['added' => 0, 'abilities_added' => 0];
 
-			foreach ($scanned as $item) {
+		foreach ($scanned as $item) {
 			$existing = $resourcesTable->find()
 				->where(['entity_class' => $item['entity_class']])
 				->first();

--- a/src/Service/ResourceSyncService.php
+++ b/src/Service/ResourceSyncService.php
@@ -100,9 +100,9 @@ class ResourceSyncService {
 		$scanned = $this->scan();
 		$result = ['added' => 0, 'abilities_added' => 0];
 
-		foreach ($scanned as $item) {
+			foreach ($scanned as $item) {
 			$existing = $resourcesTable->find()
-				->where(['name' => $item['name']])
+				->where(['entity_class' => $item['entity_class']])
 				->first();
 
 			if (!$existing && $addNew) {

--- a/src/Service/RoleSourceService.php
+++ b/src/Service/RoleSourceService.php
@@ -43,19 +43,23 @@ class RoleSourceService {
 		} elseif (is_string($roleSource)) {
 			// Configure path
 			$roles = Configure::read($roleSource);
-			static::$cachedRoles = is_array($roles) ? $roles : [];
+			static::$cachedRoles = $this->normalizeRoles(is_array($roles) ? $roles : []);
 		} elseif (is_array($roleSource)) {
 			// Direct array
-			static::$cachedRoles = $roleSource;
+			static::$cachedRoles = $this->normalizeRoles($roleSource);
 		} elseif (is_callable($roleSource)) {
 			// Callable
 			$roles = $roleSource();
-			static::$cachedRoles = is_array($roles) ? $roles : [];
+			static::$cachedRoles = $this->normalizeRoles(is_array($roles) ? $roles : []);
 		} else {
 			static::$cachedRoles = [];
 		}
 
-		return static::$cachedRoles;
+		if ($roleSource !== null && static::$cachedRoles) {
+			$this->syncExternalRoles(static::$cachedRoles);
+		}
+
+		return static::$cachedRoles ?? [];
 	}
 
 	/**
@@ -79,6 +83,7 @@ class RoleSourceService {
 					'alias' => $alias,
 					'name' => ucfirst((string)$alias),
 					'parent_id' => null,
+					'parent' => null,
 					'sort_order' => 0,
 				];
 			}
@@ -134,6 +139,72 @@ class RoleSourceService {
 			return $roles;
 		} catch (Exception $e) {
 			return [];
+		}
+	}
+
+	/**
+	 * @param array<mixed, mixed> $roles
+	 * @return array<string, int>
+	 */
+	protected function normalizeRoles(array $roles): array {
+		$result = [];
+		foreach ($roles as $alias => $id) {
+			if (!is_string($alias) || $alias === '') {
+				continue;
+			}
+			if (!is_numeric($id)) {
+				continue;
+			}
+
+			$result[$alias] = (int)$id;
+		}
+
+		return $result;
+	}
+
+	/**
+	 * Create/update shadow role rows so FK-backed permission tables remain usable.
+	 *
+	 * @param array<string, int> $roles
+	 * @return void
+	 */
+	protected function syncExternalRoles(array $roles): void {
+		try {
+			/** @var \TinyAuthBackend\Model\Table\RolesTable $rolesTable */
+			$rolesTable = TableRegistry::getTableLocator()->get('TinyAuthBackend.Roles');
+		} catch (Exception $e) {
+			return;
+		}
+
+		$sortOrder = 0;
+		foreach ($roles as $alias => $id) {
+			$sortOrder++;
+
+			$role = $rolesTable->find()->where(['id' => $id])->first();
+			if (!$role) {
+				$role = $rolesTable->find()->where(['alias' => $alias])->first();
+			}
+
+			if ($role) {
+				$role = $rolesTable->patchEntity($role, [
+					'id' => $id,
+					'alias' => $alias,
+					'name' => $role->name ?: ucfirst($alias),
+					'sort_order' => $role->sort_order ?: $sortOrder,
+				]);
+				$rolesTable->save($role);
+
+				continue;
+			}
+
+			$role = $rolesTable->newEntity([
+				'id' => $id,
+				'alias' => $alias,
+				'name' => ucfirst($alias),
+				'parent_id' => null,
+				'sort_order' => $sortOrder,
+			], ['accessibleFields' => ['id' => true]]);
+			$rolesTable->save($role);
 		}
 	}
 

--- a/src/Service/TinyAuthService.php
+++ b/src/Service/TinyAuthService.php
@@ -65,7 +65,7 @@ class TinyAuthService {
 	public function canAccessResource(EntityInterface $user, EntityInterface $entity, string $ability): bool {
 		return $this->canAccess(
 			$this->getUserRoles($user),
-			$this->getResourceName($entity),
+			$this->getResourceIdentifier($entity),
 			$ability,
 			$entity,
 			$user,
@@ -127,10 +127,15 @@ class TinyAuthService {
 		$resourceAclTable = TableRegistry::getTableLocator()->get('TinyAuthBackend.ResourceAcl');
 
 		/** @var \TinyAuthBackend\Model\Entity\ResourceAcl|null $result */
-		$result = $resourceAclTable->find()
+			$result = $resourceAclTable->find()
 			->contain(['ResourceAbilities.Resources', 'Roles', 'Scopes'])
 			->matching('ResourceAbilities.Resources', function ($q) use ($resource) {
-				return $q->where(['Resources.name' => $resource]);
+				return $q->where([
+					'OR' => [
+						'Resources.name' => $resource,
+						'Resources.entity_class' => $resource,
+					],
+				]);
 			})
 			->matching('ResourceAbilities', function ($q) use ($ability) {
 				return $q->where(['ResourceAbilities.name' => $ability]);
@@ -250,11 +255,8 @@ class TinyAuthService {
 	 * @param \Cake\Datasource\EntityInterface $entity
 	 * @return string
 	 */
-	protected function getResourceName(EntityInterface $entity): string {
-		$className = get_class($entity);
-		$parts = explode('\\', $className);
-
-		return end($parts) ?: '';
+	protected function getResourceIdentifier(EntityInterface $entity): string {
+		return get_class($entity);
 	}
 
 	/**
@@ -274,8 +276,9 @@ class TinyAuthService {
 			return $role ? [$role->alias] : [];
 		}
 
-		// Multi-role: get from user's roles association
-		$roles = $user->get('roles') ?? [];
+		// Multi-role: get from configured association/property on the user entity
+		$rolesProperty = (string)(Configure::read('TinyAuthBackend.rolesTable') ?: 'roles');
+		$roles = $user->get($rolesProperty) ?? $user->get('roles') ?? [];
 
 		return array_map(function ($r): string {
 			if (is_object($r)) {

--- a/src/Service/TinyAuthService.php
+++ b/src/Service/TinyAuthService.php
@@ -127,7 +127,7 @@ class TinyAuthService {
 		$resourceAclTable = TableRegistry::getTableLocator()->get('TinyAuthBackend.ResourceAcl');
 
 		/** @var \TinyAuthBackend\Model\Entity\ResourceAcl|null $result */
-			$result = $resourceAclTable->find()
+		$result = $resourceAclTable->find()
 			->contain(['ResourceAbilities.Resources', 'Roles', 'Scopes'])
 			->matching('ResourceAbilities.Resources', function ($q) use ($resource) {
 				return $q->where([

--- a/src/Service/TinyAuthService.php
+++ b/src/Service/TinyAuthService.php
@@ -55,6 +55,36 @@ class TinyAuthService {
 	}
 
 	/**
+	 * Convenience wrapper for entity-level authorization checks.
+	 *
+	 * @param \Cake\Datasource\EntityInterface $user The current user entity.
+	 * @param \Cake\Datasource\EntityInterface $entity The resource entity.
+	 * @param string $ability The ability name.
+	 * @return bool Whether access is allowed.
+	 */
+	public function canAccessResource(EntityInterface $user, EntityInterface $entity, string $ability): bool {
+		return $this->canAccess(
+			$this->getUserRoles($user),
+			$this->getResourceName($entity),
+			$ability,
+			$entity,
+			$user,
+		);
+	}
+
+	/**
+	 * Convenience wrapper for type-level checks without an entity instance.
+	 *
+	 * @param \Cake\Datasource\EntityInterface $user The current user entity.
+	 * @param string $resource The resource name.
+	 * @param string $ability The ability name.
+	 * @return bool Whether access is allowed.
+	 */
+	public function canPerformAbility(EntityInterface $user, string $resource, string $ability): bool {
+		return $this->canAccess($this->getUserRoles($user), $resource, $ability, null, $user);
+	}
+
+	/**
 	 * Check access for a single role.
 	 *
 	 * @param string $role The role alias.
@@ -71,25 +101,9 @@ class TinyAuthService {
 		?EntityInterface $entity,
 		?EntityInterface $user,
 	): bool {
-		$rule = $this->getResourcePermission($role, $resource, $ability);
-
+		$rule = $this->getEffectiveResourcePermission($role, $resource, $ability);
 		if (!$rule || $rule->type === 'deny') {
-			// Check parent roles if hierarchy enabled
-			if (Configure::read('TinyAuthBackend.roleHierarchy')) {
-				$parentRoles = $this->hierarchyService->getParentRoles($role);
-				foreach ($parentRoles as $parentRole) {
-					$parentRule = $this->getResourcePermission($parentRole, $resource, $ability);
-					if ($parentRule && $parentRule->type === 'allow') {
-						$rule = $parentRule;
-
-						break;
-					}
-				}
-			}
-
-			if (!$rule || $rule->type === 'deny') {
-				return false;
-			}
+			return false;
 		}
 
 		// No scope = full access
@@ -151,7 +165,7 @@ class TinyAuthService {
 		$hasFullAccess = false;
 
 		foreach ($roles as $role) {
-			$rule = $this->getResourcePermission($role, $resource, $ability);
+			$rule = $this->getEffectiveResourcePermission($role, $resource, $ability);
 
 			if (!$rule || $rule->type === 'deny') {
 				continue;
@@ -183,6 +197,37 @@ class TinyAuthService {
 	}
 
 	/**
+	 * Resolve the effective permission for a role, taking hierarchy into account.
+	 *
+	 * Direct rules win. Only missing rules inherit from descendant roles.
+	 *
+	 * @param string $role The role alias.
+	 * @param string $resource The resource name.
+	 * @param string $ability The ability name.
+	 * @return \TinyAuthBackend\Model\Entity\ResourceAcl|null
+	 */
+	protected function getEffectiveResourcePermission(string $role, string $resource, string $ability): ?ResourceAcl {
+		$rule = $this->getResourcePermission($role, $resource, $ability);
+		if ($rule) {
+			return $rule;
+		}
+
+		if (!Configure::read('TinyAuthBackend.roleHierarchy')) {
+			return null;
+		}
+
+		$descendantRoles = $this->hierarchyService->getDescendantRoleAliases($role);
+		foreach ($descendantRoles as $descendantRole) {
+			$descendantRule = $this->getResourcePermission($descendantRole, $resource, $ability);
+			if ($descendantRule) {
+				return $descendantRule;
+			}
+		}
+
+		return null;
+	}
+
+	/**
 	 * Evaluate a scope condition against an entity and user.
 	 *
 	 * @param \TinyAuthBackend\Model\Entity\Scope|null $scope The scope to evaluate.
@@ -199,6 +244,17 @@ class TinyAuthService {
 		$userValue = $user->get($scope->user_field);
 
 		return $entityValue !== null && $entityValue === $userValue;
+	}
+
+	/**
+	 * @param \Cake\Datasource\EntityInterface $entity
+	 * @return string
+	 */
+	protected function getResourceName(EntityInterface $entity): string {
+		$className = get_class($entity);
+		$parts = explode('\\', $className);
+
+		return end($parts) ?: '';
 	}
 
 	/**

--- a/src/Utility/Importer.php
+++ b/src/Utility/Importer.php
@@ -7,8 +7,7 @@ use Cake\Datasource\ModelAwareTrait;
 use TinyAuth\Auth\AclAdapter\IniAclAdapter;
 use TinyAuth\Auth\AllowAdapter\IniAllowAdapter;
 use TinyAuth\Utility\TinyAuth;
-use TinyAuthBackend\Model\Entity\AclRule;
-use TinyAuthBackend\Model\Entity\AllowRule;
+use TinyAuthBackend\Service\RoleSourceService;
 
 class Importer {
 
@@ -28,18 +27,12 @@ class Importer {
 
 		foreach ($allowData as $allowRow) {
 			foreach ($allowRow['allow'] as $action) {
-				$data = [
-					'type' => AllowRule::TYPE_ALLOW,
-					'path' => $this->path($action, $allowRow),
-				];
-				$this->addAllow($data);
+				[$controllerId, $actionId] = $this->ensureAction($allowRow, $action);
+				$this->setPublicFlag($actionId, true);
 			}
 			foreach ($allowRow['deny'] as $action) {
-				$data = [
-					'type' => AllowRule::TYPE_DENY,
-					'path' => $this->path($action, $allowRow),
-				];
-				$this->addAllow($data);
+				[$controllerId, $actionId] = $this->ensureAction($allowRow, $action);
+				$this->setPublicFlag($actionId, false);
 			}
 		}
 	}
@@ -63,21 +56,7 @@ class Importer {
 	}
 
 	/**
-	 * @param array<string, mixed> $data
-	 *
-	 * @return void
-	 */
-	protected function addAllow(array $data): void {
-		/** @var \TinyAuthBackend\Model\Table\AllowRulesTable $AllowRules */
-		$AllowRules = $this->fetchModel('TinyAuthBackend.AllowRules');
-
-		$allowRule = $AllowRules->newEntity($data);
-		$AllowRules->saveOrFail($allowRule);
-	}
-
-	/**
 	 * @param string $file
-	 *
 	 * @return void
 	 */
 	public function importAcl(string $file): void {
@@ -96,12 +75,8 @@ class Importer {
 				}
 
 				foreach ($roles as $role => $id) {
-					$data = [
-						'type' => AclRule::TYPE_ALLOW,
-						'path' => $this->path($action, $aclRow),
-						'role' => $role,
-					];
-					$this->addAcl($data);
+					[$controllerId, $actionId] = $this->ensureAction($aclRow, $action);
+					$this->upsertAclPermission($actionId, $role, 'allow');
 				}
 			}
 			foreach ($aclRow['deny'] as $action => $roles) {
@@ -111,54 +86,133 @@ class Importer {
 				}
 
 				foreach ($roles as $role => $id) {
-					$data = [
-						'type' => AclRule::TYPE_DENY,
-						'path' => $this->path($action, $aclRow),
-						'role' => $role,
-					];
-					$this->addAcl($data);
+					[$controllerId, $actionId] = $this->ensureAction($aclRow, $action);
+					$this->upsertAclPermission($actionId, $role, 'deny');
 				}
 			}
 		}
 	}
 
 	/**
-	 * @param array<string, mixed> $data
+	 * Initialize ACL for specific role to have initial access to the backend.
 	 *
+	 * @param string $roleAlias
 	 * @return void
 	 */
-	protected function addAcl(array $data): void {
-		/** @var \TinyAuthBackend\Model\Table\AclRulesTable $AclRules */
-		$AclRules = $this->fetchModel('TinyAuthBackend.AclRules');
+	public function initializeAcl(string $roleAlias): void {
+		$roleId = (new RoleSourceService())->getRoles()[$roleAlias] ?? null;
+		if ($roleId === null) {
+			return;
+		}
 
-		$aclRule = $AclRules->newEntity($data);
-		$AclRules->saveOrFail($aclRule);
+		$controllerSyncService = new \TinyAuthBackend\Service\ControllerSyncService();
+		$controllerSyncService->sync();
+
+		/** @var \TinyAuthBackend\Model\Table\TinyauthControllersTable $controllersTable */
+		$controllersTable = $this->fetchModel('TinyAuthBackend.TinyauthControllers');
+		$controllers = $controllersTable->find()
+			->contain(['Actions'])
+			->where([
+				'plugin' => 'TinyAuthBackend',
+				'prefix' => 'Admin',
+			])
+			->all();
+
+		/** @var \TinyAuthBackend\Model\Entity\TinyauthController $controller */
+		foreach ($controllers as $controller) {
+			foreach ($controller->actions as $action) {
+				$this->upsertAclPermission($action->id, $roleAlias, 'allow');
+			}
+		}
 	}
 
 	/**
-	 * Initialize ACL for specific role to have initial access to the backend.
-	 *
-	 * @param string $role
-	 *
+	 * @param array<string, mixed> $row
+	 * @param string $actionName
+	 * @return array{0: int, 1: int}
+	 */
+	protected function ensureAction(array $row, string $actionName): array {
+		/** @var \TinyAuthBackend\Model\Table\TinyauthControllersTable $controllersTable */
+		$controllersTable = $this->fetchModel('TinyAuthBackend.TinyauthControllers');
+		/** @var \TinyAuthBackend\Model\Table\ActionsTable $actionsTable */
+		$actionsTable = $this->fetchModel('TinyAuthBackend.Actions');
+
+		$controller = $controllersTable->find()
+			->where([
+				'plugin IS' => $row['plugin'],
+				'prefix IS' => $row['prefix'],
+				'name' => $row['controller'],
+			])
+			->first();
+
+		if (!$controller) {
+			$controller = $controllersTable->newEntity([
+				'plugin' => $row['plugin'],
+				'prefix' => $row['prefix'],
+				'name' => $row['controller'],
+			]);
+			$controllersTable->saveOrFail($controller);
+		}
+
+		$action = $actionsTable->find()
+			->where([
+				'controller_id' => $controller->id,
+				'name' => $actionName,
+			])
+			->first();
+
+		if (!$action) {
+			$action = $actionsTable->newEntity([
+				'controller_id' => $controller->id,
+				'name' => $actionName,
+				'is_public' => false,
+			]);
+			$actionsTable->saveOrFail($action);
+		}
+
+		return [$controller->id, $action->id];
+	}
+
+	/**
+	 * @param int $actionId
+	 * @param bool $isPublic
 	 * @return void
 	 */
-	public function initializeAcl(string $role): void {
-		$paths = [
-			'TinyAuthBackend.Auth::*',
-			'TinyAuthBackend.Allow::*',
-			'TinyAuthBackend.Acl::*',
-		];
+	protected function setPublicFlag(int $actionId, bool $isPublic): void {
+		/** @var \TinyAuthBackend\Model\Table\ActionsTable $actionsTable */
+		$actionsTable = $this->fetchModel('TinyAuthBackend.Actions');
+		$action = $actionsTable->get($actionId);
+		$action->is_public = $isPublic;
+		$actionsTable->saveOrFail($action);
+	}
 
-		/** @var \TinyAuthBackend\Model\Table\AclRulesTable $AclRules */
-		$AclRules = $this->fetchModel('TinyAuthBackend.AclRules');
-		foreach ($paths as $path) {
-			$aclRule = $AclRules->newEntity([
-				'type' => AclRule::TYPE_ALLOW,
-				'role' => $role,
-				'path' => $path,
-			]);
-			$AclRules->saveOrFail($aclRule);
+	/**
+	 * @param int $actionId
+	 * @param string $roleAlias
+	 * @param string $type
+	 * @return void
+	 */
+	protected function upsertAclPermission(int $actionId, string $roleAlias, string $type): void {
+		$roleId = (new RoleSourceService())->getRoles()[$roleAlias] ?? null;
+		if ($roleId === null || $roleAlias === '*') {
+			return;
 		}
+
+		/** @var \TinyAuthBackend\Model\Table\AclPermissionsTable $permissionsTable */
+		$permissionsTable = $this->fetchModel('TinyAuthBackend.AclPermissions');
+		$permission = $permissionsTable->find()
+			->where(['action_id' => $actionId, 'role_id' => $roleId])
+			->first();
+
+		if (!$permission) {
+			$permission = $permissionsTable->newEntity([
+				'action_id' => $actionId,
+				'role_id' => $roleId,
+			]);
+		}
+
+		$permission->type = $type;
+		$permissionsTable->saveOrFail($permission);
 	}
 
 }

--- a/src/Utility/Importer.php
+++ b/src/Utility/Importer.php
@@ -7,6 +7,7 @@ use Cake\Datasource\ModelAwareTrait;
 use TinyAuth\Auth\AclAdapter\IniAclAdapter;
 use TinyAuth\Auth\AllowAdapter\IniAllowAdapter;
 use TinyAuth\Utility\TinyAuth;
+use TinyAuthBackend\Service\ControllerSyncService;
 use TinyAuthBackend\Service\RoleSourceService;
 
 class Importer {
@@ -105,7 +106,7 @@ class Importer {
 			return;
 		}
 
-		$controllerSyncService = new \TinyAuthBackend\Service\ControllerSyncService();
+		$controllerSyncService = new ControllerSyncService();
 		$controllerSyncService->sync();
 
 		/** @var \TinyAuthBackend\Model\Table\TinyauthControllersTable $controllersTable */

--- a/templates/Admin/Resources/index.php
+++ b/templates/Admin/Resources/index.php
@@ -25,8 +25,9 @@ $this->assign('title', 'Resource Permissions');
 				<?php foreach ($resources as $resource) { ?>
 				<a href="<?= $this->Url->build(['action' => 'index', '?' => ['resource_id' => $resource->id]]) ?>"
 				   class="tree-item block <?= $selectedResource && $selectedResource->id === $resource->id ? 'active' : '' ?>">
-					<?= h($resource->name) ?>
-					<span class="text-xs text-gray-400">(<?= count($resource->resource_abilities) ?>)</span>
+					<div class="font-medium"><?= h($resource->name) ?></div>
+					<div class="text-xs text-gray-400"><?= h($resource->entity_class) ?></div>
+					<div class="text-xs text-gray-400">(<?= count($resource->resource_abilities) ?>)</div>
 				</a>
 				<?php } ?>
 			</div>

--- a/tests/Fixture/TinyAuthResourcesFixture.php
+++ b/tests/Fixture/TinyAuthResourcesFixture.php
@@ -31,7 +31,7 @@ class TinyAuthResourcesFixture extends TestFixture {
 		'modified' => ['type' => 'datetime', 'length' => null, 'null' => true, 'default' => null, 'comment' => '', 'precision' => null],
 		'_constraints' => [
 			'primary' => ['type' => 'primary', 'columns' => ['id'], 'length' => []],
-			'tinyauth_resources_name_unique' => ['type' => 'unique', 'columns' => ['name'], 'length' => []],
+			'tinyauth_resources_entity_class_unique' => ['type' => 'unique', 'columns' => ['entity_class'], 'length' => []],
 		],
 		'_options' => [
 			'engine' => 'InnoDB',

--- a/tests/TestCase/Command/InitCommandTest.php
+++ b/tests/TestCase/Command/InitCommandTest.php
@@ -1,0 +1,50 @@
+<?php
+declare(strict_types=1);
+
+namespace TinyAuthBackend\Test\TestCase\Command;
+
+use Cake\Console\TestSuite\ConsoleIntegrationTestTrait;
+use Cake\Core\Configure;
+use Cake\ORM\TableRegistry;
+use Cake\TestSuite\TestCase;
+
+class InitCommandTest extends TestCase {
+
+	use ConsoleIntegrationTestTrait;
+
+	protected array $fixtures = [
+		'plugin.TinyAuthBackend.TinyAuthRoles',
+		'plugin.TinyAuthBackend.TinyAuthControllers',
+		'plugin.TinyAuthBackend.TinyAuthActions',
+		'plugin.TinyAuthBackend.TinyAuthAclPermissions',
+	];
+
+	public function setUp(): void {
+		parent::setUp();
+
+		$this->loadPlugins(['TinyAuthBackend']);
+		Configure::write('Roles', ['admin' => 1]);
+
+		$this->insertRow('tinyauth_roles', [
+			'id' => 1,
+			'name' => 'Admin',
+			'alias' => 'admin',
+			'parent_id' => null,
+			'sort_order' => 1,
+		]);
+	}
+
+	public function testInitCommandOutputsDashboardUrlAndCreatesPermissions(): void {
+		$this->exec('tiny_auth_backend init admin');
+
+		$this->assertExitSuccess();
+		$this->assertOutputContains('/admin/auth');
+		$this->assertOutputNotContains('/auth/index');
+		$this->assertGreaterThan(0, TableRegistry::getTableLocator()->get('tinyauth_acl_permissions')->find()->count());
+	}
+
+	protected function insertRow(string $table, array $data): void {
+		TableRegistry::getTableLocator()->get($table)->getConnection()->insert($table, $data);
+	}
+
+}

--- a/tests/TestCase/Command/InitCommandTest.php
+++ b/tests/TestCase/Command/InitCommandTest.php
@@ -7,10 +7,12 @@ use Cake\Console\TestSuite\ConsoleIntegrationTestTrait;
 use Cake\Core\Configure;
 use Cake\ORM\TableRegistry;
 use Cake\TestSuite\TestCase;
+use TinyAuthBackend\Test\TestSuite\DatabaseTestTrait;
 
 class InitCommandTest extends TestCase {
 
 	use ConsoleIntegrationTestTrait;
+	use DatabaseTestTrait;
 
 	protected array $fixtures = [
 		'plugin.TinyAuthBackend.TinyAuthRoles',
@@ -41,10 +43,6 @@ class InitCommandTest extends TestCase {
 		$this->assertOutputContains('/admin/auth');
 		$this->assertOutputNotContains('/auth/index');
 		$this->assertGreaterThan(0, TableRegistry::getTableLocator()->get('tinyauth_acl_permissions')->find()->count());
-	}
-
-	protected function insertRow(string $table, array $data): void {
-		TableRegistry::getTableLocator()->get($table)->getConnection()->insert($table, $data);
 	}
 
 }

--- a/tests/TestCase/Controller/Admin/AclControllerTest.php
+++ b/tests/TestCase/Controller/Admin/AclControllerTest.php
@@ -4,14 +4,15 @@ declare(strict_types=1);
 namespace TinyAuthBackend\Test\TestCase\Controller\Admin;
 
 use Cake\Core\Configure;
-use Cake\ORM\TableRegistry;
 use Cake\TestSuite\IntegrationTestTrait;
 use Cake\TestSuite\TestCase;
 use TinyAuthBackend\Auth\AclAdapter\DbAclAdapter;
 use TinyAuthBackend\Service\RoleSourceService;
+use TinyAuthBackend\Test\TestSuite\DatabaseTestTrait;
 
 class AclControllerTest extends TestCase {
 
+	use DatabaseTestTrait;
 	use IntegrationTestTrait;
 
 	protected array $fixtures = [
@@ -101,14 +102,6 @@ class AclControllerTest extends TestCase {
 
 		$this->assertResponseCode(200);
 		$this->assertResponseContains('index');
-	}
-
-	protected function insertRow(string $table, array $data): void {
-		TableRegistry::getTableLocator()->get($table)->getConnection()->insert($table, $data);
-	}
-
-	protected function countRows(string $table, array $conditions): int {
-		return TableRegistry::getTableLocator()->get($table)->find()->where($conditions)->count();
 	}
 
 }

--- a/tests/TestCase/Controller/Admin/AclControllerTest.php
+++ b/tests/TestCase/Controller/Admin/AclControllerTest.php
@@ -1,26 +1,19 @@
 <?php
+declare(strict_types=1);
 
 namespace TinyAuthBackend\Test\TestCase\Controller\Admin;
 
 use Cake\Core\Configure;
+use Cake\ORM\TableRegistry;
 use Cake\TestSuite\IntegrationTestTrait;
 use Cake\TestSuite\TestCase;
 use TinyAuthBackend\Auth\AclAdapter\DbAclAdapter;
+use TinyAuthBackend\Service\RoleSourceService;
 
-/**
- * TinyAuthBackend\Controller\TinyAuthAclRulesController Test Case
- *
- * @uses \TinyAuthBackend\Controller\Admin\AclController
- */
 class AclControllerTest extends TestCase {
 
 	use IntegrationTestTrait;
 
-	/**
-	 * Fixtures
-	 *
-	 * @var array
-	 */
 	protected array $fixtures = [
 		'plugin.TinyAuthBackend.TinyAuthRoles',
 		'plugin.TinyAuthBackend.TinyAuthControllers',
@@ -28,70 +21,94 @@ class AclControllerTest extends TestCase {
 		'plugin.TinyAuthBackend.TinyAuthAclPermissions',
 	];
 
-	/**
-	 * @return void
-	 */
 	public function setUp(): void {
 		parent::setUp();
 
 		$this->loadPlugins(['TinyAuthBackend']);
-
-		Configure::write('Roles', [
-			'user' => ROLE_USER,
-			'moderator' => ROLE_MODERATOR,
-			'admin' => ROLE_ADMIN,
-		]);
-
 		Configure::write('TinyAuth.aclAdapter', DbAclAdapter::class);
+		Configure::write('TinyAuthBackend.roleSource', null);
+		(new RoleSourceService())->clearCache();
+
+		$this->insertRow('tinyauth_roles', [
+			'id' => 1,
+			'name' => 'User',
+			'alias' => 'user',
+			'parent_id' => null,
+			'sort_order' => 1,
+		]);
+		$this->insertRow('tinyauth_roles', [
+			'id' => 2,
+			'name' => 'Admin',
+			'alias' => 'admin',
+			'parent_id' => null,
+			'sort_order' => 2,
+		]);
+		$this->insertRow('tinyauth_controllers', [
+			'id' => 1,
+			'plugin' => null,
+			'prefix' => 'Admin',
+			'name' => 'Articles',
+		]);
+		$this->insertRow('tinyauth_actions', [
+			'id' => 1,
+			'controller_id' => 1,
+			'name' => 'index',
+			'is_public' => false,
+		]);
 	}
 
-	/**
-	 * Test index method
-	 *
-	 * @return void
-	 */
-	public function testIndex() {
+	public function testIndex(): void {
 		$this->disableErrorHandlerMiddleware();
 
-		$this->get(['prefix' => 'Admin', 'plugin' => 'TinyAuthBackend', 'controller' => 'Acl']);
+		$this->get(['prefix' => 'Admin', 'plugin' => 'TinyAuthBackend', 'controller' => 'Acl', '?' => ['controller_id' => 1]]);
 
 		$this->assertResponseCode(200);
+		$this->assertResponseContains('Articles');
+		$this->assertResponseContains('index');
 	}
 
-	/**
-	 * Test view method
-	 *
-	 * @return void
-	 */
-	public function testView() {
-		$this->markTestIncomplete('Not implemented yet.');
+	public function testToggleCreatesPermission(): void {
+		$this->post(['prefix' => 'Admin', 'plugin' => 'TinyAuthBackend', 'controller' => 'Acl', 'action' => 'toggle'], [
+			'action_id' => 1,
+			'role_id' => 1,
+			'type' => 'allow',
+		]);
+
+		$this->assertResponseCode(200);
+		$this->assertSame(1, $this->countRows('tinyauth_acl_permissions', ['action_id' => 1, 'role_id' => 1, 'type' => 'allow']));
 	}
 
-	/**
-	 * Test add method
-	 *
-	 * @return void
-	 */
-	public function testAdd() {
-		$this->markTestIncomplete('Not implemented yet.');
+	public function testToggleUpdatesPermission(): void {
+		$this->insertRow('tinyauth_acl_permissions', [
+			'id' => 1,
+			'action_id' => 1,
+			'role_id' => 1,
+			'type' => 'allow',
+		]);
+
+		$this->post(['prefix' => 'Admin', 'plugin' => 'TinyAuthBackend', 'controller' => 'Acl', 'action' => 'toggle'], [
+			'action_id' => 1,
+			'role_id' => 1,
+			'type' => 'deny',
+		]);
+
+		$this->assertResponseCode(200);
+		$this->assertSame(1, $this->countRows('tinyauth_acl_permissions', ['action_id' => 1, 'role_id' => 1, 'type' => 'deny']));
 	}
 
-	/**
-	 * Test edit method
-	 *
-	 * @return void
-	 */
-	public function testEdit() {
-		$this->markTestIncomplete('Not implemented yet.');
+	public function testSearchReturnsMatchingInternalRecords(): void {
+		$this->get(['prefix' => 'Admin', 'plugin' => 'TinyAuthBackend', 'controller' => 'Acl', 'action' => 'search', '?' => ['q' => 'ind']]);
+
+		$this->assertResponseCode(200);
+		$this->assertResponseContains('index');
 	}
 
-	/**
-	 * Test delete method
-	 *
-	 * @return void
-	 */
-	public function testDelete() {
-		$this->markTestIncomplete('Not implemented yet.');
+	protected function insertRow(string $table, array $data): void {
+		TableRegistry::getTableLocator()->get($table)->getConnection()->insert($table, $data);
+	}
+
+	protected function countRows(string $table, array $conditions): int {
+		return TableRegistry::getTableLocator()->get($table)->find()->where($conditions)->count();
 	}
 
 }

--- a/tests/TestCase/Controller/Admin/AllowControllerTest.php
+++ b/tests/TestCase/Controller/Admin/AllowControllerTest.php
@@ -3,12 +3,13 @@ declare(strict_types=1);
 
 namespace TinyAuthBackend\Test\TestCase\Controller\Admin;
 
-use Cake\ORM\TableRegistry;
 use Cake\TestSuite\IntegrationTestTrait;
 use Cake\TestSuite\TestCase;
+use TinyAuthBackend\Test\TestSuite\DatabaseTestTrait;
 
 class AllowControllerTest extends TestCase {
 
+	use DatabaseTestTrait;
 	use IntegrationTestTrait;
 
 	protected array $fixtures = [
@@ -67,14 +68,6 @@ class AllowControllerTest extends TestCase {
 
 		$this->assertResponseCode(302);
 		$this->assertSame(2, $this->countRows('tinyauth_actions', ['controller_id' => 1, 'is_public' => true]));
-	}
-
-	protected function insertRow(string $table, array $data): void {
-		TableRegistry::getTableLocator()->get($table)->getConnection()->insert($table, $data);
-	}
-
-	protected function countRows(string $table, array $conditions): int {
-		return TableRegistry::getTableLocator()->get($table)->find()->where($conditions)->count();
 	}
 
 }

--- a/tests/TestCase/Controller/Admin/AllowControllerTest.php
+++ b/tests/TestCase/Controller/Admin/AllowControllerTest.php
@@ -3,52 +3,78 @@ declare(strict_types=1);
 
 namespace TinyAuthBackend\Test\TestCase\Controller\Admin;
 
+use Cake\ORM\TableRegistry;
 use Cake\TestSuite\IntegrationTestTrait;
 use Cake\TestSuite\TestCase;
 
-/**
- * TinyAuthBackend\Controller\Admin\AllowController Test Case
- *
- * @uses \TinyAuthBackend\Controller\Admin\AllowController
- */
 class AllowControllerTest extends TestCase {
 
 	use IntegrationTestTrait;
 
-	/**
-	 * @return void
-	 */
+	protected array $fixtures = [
+		'plugin.TinyAuthBackend.TinyAuthControllers',
+		'plugin.TinyAuthBackend.TinyAuthActions',
+	];
+
 	public function setUp(): void {
 		parent::setUp();
 
 		$this->loadPlugins(['TinyAuthBackend']);
+
+		$this->insertRow('tinyauth_controllers', [
+			'id' => 1,
+			'plugin' => null,
+			'prefix' => null,
+			'name' => 'Pages',
+		]);
+		$this->insertRow('tinyauth_actions', [
+			'id' => 1,
+			'controller_id' => 1,
+			'name' => 'display',
+			'is_public' => false,
+		]);
+		$this->insertRow('tinyauth_actions', [
+			'id' => 2,
+			'controller_id' => 1,
+			'name' => 'view',
+			'is_public' => false,
+		]);
 	}
 
-	/**
-	 * Test index method
-	 *
-	 * @return void
-	 */
 	public function testIndex(): void {
-		$this->markTestIncomplete('Requires database fixtures for new tables.');
+		$this->get(['prefix' => 'Admin', 'plugin' => 'TinyAuthBackend', 'controller' => 'Allow']);
+
+		$this->assertResponseCode(200);
+		$this->assertResponseContains('Pages');
+		$this->assertResponseContains('display');
 	}
 
-	/**
-	 * Test toggle method
-	 *
-	 * @return void
-	 */
 	public function testToggle(): void {
-		$this->markTestIncomplete('Requires database fixtures for new tables.');
+		$this->post(['prefix' => 'Admin', 'plugin' => 'TinyAuthBackend', 'controller' => 'Allow', 'action' => 'toggle'], [
+			'action_id' => 1,
+			'is_public' => 'true',
+		]);
+
+		$this->assertResponseCode(200);
+		$this->assertSame(1, $this->countRows('tinyauth_actions', ['id' => 1, 'is_public' => true]));
 	}
 
-	/**
-	 * Test bulkToggle method
-	 *
-	 * @return void
-	 */
 	public function testBulkToggle(): void {
-		$this->markTestIncomplete('Requires database fixtures for new tables.');
+		$this->post(['prefix' => 'Admin', 'plugin' => 'TinyAuthBackend', 'controller' => 'Allow', 'action' => 'bulkToggle'], [
+			'controller_id' => 1,
+			'is_public' => 'true',
+		]);
+
+		$this->assertResponseCode(302);
+		$this->assertSame(2, $this->countRows('tinyauth_actions', ['controller_id' => 1, 'is_public' => true]));
+	}
+
+	protected function insertRow(string $table, array $data): void {
+		TableRegistry::getTableLocator()->get($table)->getConnection()->insert($table, $data);
+	}
+
+	protected function countRows(string $table, array $conditions): int {
+		return TableRegistry::getTableLocator()->get($table)->find()->where($conditions)->count();
 	}
 
 }

--- a/tests/TestCase/Controller/Admin/DashboardControllerTest.php
+++ b/tests/TestCase/Controller/Admin/DashboardControllerTest.php
@@ -4,13 +4,14 @@ declare(strict_types=1);
 namespace TinyAuthBackend\Test\TestCase\Controller\Admin;
 
 use Cake\Core\Configure;
-use Cake\ORM\TableRegistry;
 use Cake\TestSuite\IntegrationTestTrait;
 use Cake\TestSuite\TestCase;
 use TinyAuthBackend\Service\RoleSourceService;
+use TinyAuthBackend\Test\TestSuite\DatabaseTestTrait;
 
 class DashboardControllerTest extends TestCase {
 
+	use DatabaseTestTrait;
 	use IntegrationTestTrait;
 
 	protected array $fixtures = [
@@ -77,10 +78,6 @@ class DashboardControllerTest extends TestCase {
 
 		$this->assertResponseCode(200);
 		$this->assertResponseContains('Concepts');
-	}
-
-	protected function insertRow(string $table, array $data): void {
-		TableRegistry::getTableLocator()->get($table)->getConnection()->insert($table, $data);
 	}
 
 }

--- a/tests/TestCase/Controller/Admin/DashboardControllerTest.php
+++ b/tests/TestCase/Controller/Admin/DashboardControllerTest.php
@@ -1,0 +1,86 @@
+<?php
+declare(strict_types=1);
+
+namespace TinyAuthBackend\Test\TestCase\Controller\Admin;
+
+use Cake\Core\Configure;
+use Cake\ORM\TableRegistry;
+use Cake\TestSuite\IntegrationTestTrait;
+use Cake\TestSuite\TestCase;
+use TinyAuthBackend\Service\RoleSourceService;
+
+class DashboardControllerTest extends TestCase {
+
+	use IntegrationTestTrait;
+
+	protected array $fixtures = [
+		'plugin.TinyAuthBackend.TinyAuthRoles',
+		'plugin.TinyAuthBackend.TinyAuthControllers',
+		'plugin.TinyAuthBackend.TinyAuthActions',
+		'plugin.TinyAuthBackend.TinyAuthAclPermissions',
+		'plugin.TinyAuthBackend.TinyAuthResources',
+		'plugin.TinyAuthBackend.TinyAuthResourceAbilities',
+		'plugin.TinyAuthBackend.TinyAuthResourceAcl',
+		'plugin.TinyAuthBackend.TinyAuthScopes',
+	];
+
+	public function setUp(): void {
+		parent::setUp();
+
+		$this->loadPlugins(['TinyAuthBackend']);
+		Configure::write('TinyAuthBackend.roleSource', ['editor' => 7, 'admin' => 9]);
+		(new RoleSourceService())->clearCache();
+
+		$this->insertRow('tinyauth_controllers', [
+			'id' => 1,
+			'plugin' => null,
+			'prefix' => null,
+			'name' => 'Pages',
+		]);
+		$this->insertRow('tinyauth_actions', [
+			'id' => 1,
+			'controller_id' => 1,
+			'name' => 'display',
+			'is_public' => true,
+		]);
+		$this->insertRow('tinyauth_resources', [
+			'id' => 1,
+			'name' => 'Article',
+			'entity_class' => 'TestApp\Model\Entity\Article',
+			'table_name' => 'articles',
+		]);
+		$this->insertRow('tinyauth_resource_abilities', [
+			'id' => 1,
+			'resource_id' => 1,
+			'name' => 'view',
+			'description' => null,
+		]);
+		$this->insertRow('tinyauth_scopes', [
+			'id' => 1,
+			'name' => 'own',
+			'description' => 'Own rows',
+			'entity_field' => 'user_id',
+			'user_field' => 'id',
+		]);
+	}
+
+	public function testIndex(): void {
+		$this->get(['prefix' => 'Admin', 'plugin' => 'TinyAuthBackend', 'controller' => 'Dashboard']);
+
+		$this->assertResponseCode(200);
+		$this->assertResponseContains('Dashboard');
+		$this->assertResponseContains('Pages');
+	}
+
+	public function testConcepts(): void {
+		$this->get(['prefix' => 'Admin', 'plugin' => 'TinyAuthBackend', 'controller' => 'Dashboard', 'action' => 'concepts']);
+
+		$this->assertResponseCode(200);
+		$this->assertResponseContains('Concepts');
+	}
+
+	protected function insertRow(string $table, array $data): void {
+		TableRegistry::getTableLocator()->get($table)->getConnection()->insert($table, $data);
+	}
+
+}

--- a/tests/TestCase/Controller/Admin/ResourcesControllerTest.php
+++ b/tests/TestCase/Controller/Admin/ResourcesControllerTest.php
@@ -1,0 +1,113 @@
+<?php
+declare(strict_types=1);
+
+namespace TinyAuthBackend\Test\TestCase\Controller\Admin;
+
+use Cake\Core\Configure;
+use Cake\ORM\TableRegistry;
+use Cake\TestSuite\IntegrationTestTrait;
+use Cake\TestSuite\TestCase;
+use TinyAuthBackend\Service\RoleSourceService;
+
+class ResourcesControllerTest extends TestCase {
+
+	use IntegrationTestTrait;
+
+	protected array $fixtures = [
+		'plugin.TinyAuthBackend.TinyAuthRoles',
+		'plugin.TinyAuthBackend.TinyAuthResources',
+		'plugin.TinyAuthBackend.TinyAuthResourceAbilities',
+		'plugin.TinyAuthBackend.TinyAuthResourceAcl',
+		'plugin.TinyAuthBackend.TinyAuthScopes',
+	];
+
+	public function setUp(): void {
+		parent::setUp();
+
+		$this->loadPlugins(['TinyAuthBackend']);
+		Configure::write('TinyAuthBackend.roleSource', null);
+		(new RoleSourceService())->clearCache();
+
+		$this->insertRow('tinyauth_roles', [
+			'id' => 1,
+			'name' => 'User',
+			'alias' => 'user',
+			'parent_id' => null,
+			'sort_order' => 1,
+		]);
+		$this->insertRow('tinyauth_resources', [
+			'id' => 1,
+			'name' => 'Article',
+			'entity_class' => 'TestApp\Model\Entity\Article',
+			'table_name' => 'articles',
+		]);
+		$this->insertRow('tinyauth_resource_abilities', [
+			'id' => 1,
+			'resource_id' => 1,
+			'name' => 'edit',
+			'description' => null,
+		]);
+		$this->insertRow('tinyauth_scopes', [
+			'id' => 1,
+			'name' => 'own',
+			'description' => 'Own rows',
+			'entity_field' => 'user_id',
+			'user_field' => 'id',
+		]);
+	}
+
+	public function testIndex(): void {
+		$this->get(['prefix' => 'Admin', 'plugin' => 'TinyAuthBackend', 'controller' => 'Resources', '?' => ['resource_id' => 1]]);
+
+		$this->assertResponseCode(200);
+		$this->assertResponseContains('Article');
+		$this->assertResponseContains('TestApp\\Model\\Entity\\Article');
+		$this->assertResponseContains('edit');
+	}
+
+	public function testToggleCreatesScopedPermission(): void {
+		$this->post(['prefix' => 'Admin', 'plugin' => 'TinyAuthBackend', 'controller' => 'Resources', 'action' => 'toggle'], [
+			'ability_id' => 1,
+			'role_id' => 1,
+			'type' => 'allow',
+			'scope_id' => 1,
+		]);
+
+		$this->assertResponseCode(200);
+		$this->assertSame(1, $this->countRows('tinyauth_resource_acl', [
+			'resource_ability_id' => 1,
+			'role_id' => 1,
+			'type' => 'allow',
+			'scope_id' => 1,
+		]));
+	}
+
+	public function testAddAbility(): void {
+		$this->post(['prefix' => 'Admin', 'plugin' => 'TinyAuthBackend', 'controller' => 'Resources', 'action' => 'addAbility'], [
+			'resource_id' => 1,
+			'name' => 'publish',
+		]);
+
+		$this->assertResponseCode(302);
+		$this->assertSame(1, $this->countRows('tinyauth_resource_abilities', [
+			'resource_id' => 1,
+			'name' => 'publish',
+		]));
+	}
+
+	public function testDeleteAbility(): void {
+		$this->post(['prefix' => 'Admin', 'plugin' => 'TinyAuthBackend', 'controller' => 'Resources', 'action' => 'deleteAbility', 1]);
+
+		$this->assertResponseCode(302);
+		$this->assertSame(0, $this->countRows('tinyauth_resource_abilities', ['id' => 1]));
+	}
+
+	protected function insertRow(string $table, array $data): void {
+		TableRegistry::getTableLocator()->get($table)->getConnection()->insert($table, $data);
+	}
+
+	protected function countRows(string $table, array $conditions): int {
+		return TableRegistry::getTableLocator()->get($table)->find()->where($conditions)->count();
+	}
+
+}

--- a/tests/TestCase/Controller/Admin/ResourcesControllerTest.php
+++ b/tests/TestCase/Controller/Admin/ResourcesControllerTest.php
@@ -4,13 +4,14 @@ declare(strict_types=1);
 namespace TinyAuthBackend\Test\TestCase\Controller\Admin;
 
 use Cake\Core\Configure;
-use Cake\ORM\TableRegistry;
 use Cake\TestSuite\IntegrationTestTrait;
 use Cake\TestSuite\TestCase;
 use TinyAuthBackend\Service\RoleSourceService;
+use TinyAuthBackend\Test\TestSuite\DatabaseTestTrait;
 
 class ResourcesControllerTest extends TestCase {
 
+	use DatabaseTestTrait;
 	use IntegrationTestTrait;
 
 	protected array $fixtures = [
@@ -100,14 +101,6 @@ class ResourcesControllerTest extends TestCase {
 
 		$this->assertResponseCode(302);
 		$this->assertSame(0, $this->countRows('tinyauth_resource_abilities', ['id' => 1]));
-	}
-
-	protected function insertRow(string $table, array $data): void {
-		TableRegistry::getTableLocator()->get($table)->getConnection()->insert($table, $data);
-	}
-
-	protected function countRows(string $table, array $conditions): int {
-		return TableRegistry::getTableLocator()->get($table)->find()->where($conditions)->count();
 	}
 
 }

--- a/tests/TestCase/Controller/Admin/ScopesControllerTest.php
+++ b/tests/TestCase/Controller/Admin/ScopesControllerTest.php
@@ -1,0 +1,79 @@
+<?php
+declare(strict_types=1);
+
+namespace TinyAuthBackend\Test\TestCase\Controller\Admin;
+
+use Cake\ORM\TableRegistry;
+use Cake\TestSuite\IntegrationTestTrait;
+use Cake\TestSuite\TestCase;
+
+class ScopesControllerTest extends TestCase {
+
+	use IntegrationTestTrait;
+
+	protected array $fixtures = [
+		'plugin.TinyAuthBackend.TinyAuthScopes',
+		'plugin.TinyAuthBackend.TinyAuthResourceAcl',
+	];
+
+	public function setUp(): void {
+		parent::setUp();
+
+		$this->loadPlugins(['TinyAuthBackend']);
+
+		$this->insertRow('tinyauth_scopes', [
+			'id' => 1,
+			'name' => 'own',
+			'description' => 'Own rows',
+			'entity_field' => 'user_id',
+			'user_field' => 'id',
+		]);
+	}
+
+	public function testIndex(): void {
+		$this->get(['prefix' => 'Admin', 'plugin' => 'TinyAuthBackend', 'controller' => 'Scopes']);
+
+		$this->assertResponseCode(200);
+		$this->assertResponseContains('own');
+	}
+
+	public function testAdd(): void {
+		$this->post(['prefix' => 'Admin', 'plugin' => 'TinyAuthBackend', 'controller' => 'Scopes', 'action' => 'add'], [
+			'name' => 'team',
+			'description' => 'Same team',
+			'entity_field' => 'team_id',
+			'user_field' => 'team_id',
+		]);
+
+		$this->assertResponseCode(302);
+		$this->assertSame(1, $this->countRows('tinyauth_scopes', ['name' => 'team']));
+	}
+
+	public function testEdit(): void {
+		$this->post(['prefix' => 'Admin', 'plugin' => 'TinyAuthBackend', 'controller' => 'Scopes', 'action' => 'edit', 1], [
+			'name' => 'own',
+			'description' => 'Updated',
+			'entity_field' => 'user_id',
+			'user_field' => 'id',
+		]);
+
+		$this->assertResponseCode(302);
+		$this->assertSame(1, $this->countRows('tinyauth_scopes', ['id' => 1, 'description' => 'Updated']));
+	}
+
+	public function testDelete(): void {
+		$this->post(['prefix' => 'Admin', 'plugin' => 'TinyAuthBackend', 'controller' => 'Scopes', 'action' => 'delete', 1]);
+
+		$this->assertResponseCode(302);
+		$this->assertSame(0, $this->countRows('tinyauth_scopes', ['id' => 1]));
+	}
+
+	protected function insertRow(string $table, array $data): void {
+		TableRegistry::getTableLocator()->get($table)->getConnection()->insert($table, $data);
+	}
+
+	protected function countRows(string $table, array $conditions): int {
+		return TableRegistry::getTableLocator()->get($table)->find()->where($conditions)->count();
+	}
+
+}

--- a/tests/TestCase/Controller/Admin/ScopesControllerTest.php
+++ b/tests/TestCase/Controller/Admin/ScopesControllerTest.php
@@ -3,12 +3,13 @@ declare(strict_types=1);
 
 namespace TinyAuthBackend\Test\TestCase\Controller\Admin;
 
-use Cake\ORM\TableRegistry;
 use Cake\TestSuite\IntegrationTestTrait;
 use Cake\TestSuite\TestCase;
+use TinyAuthBackend\Test\TestSuite\DatabaseTestTrait;
 
 class ScopesControllerTest extends TestCase {
 
+	use DatabaseTestTrait;
 	use IntegrationTestTrait;
 
 	protected array $fixtures = [
@@ -66,14 +67,6 @@ class ScopesControllerTest extends TestCase {
 
 		$this->assertResponseCode(302);
 		$this->assertSame(0, $this->countRows('tinyauth_scopes', ['id' => 1]));
-	}
-
-	protected function insertRow(string $table, array $data): void {
-		TableRegistry::getTableLocator()->get($table)->getConnection()->insert($table, $data);
-	}
-
-	protected function countRows(string $table, array $conditions): int {
-		return TableRegistry::getTableLocator()->get($table)->find()->where($conditions)->count();
 	}
 
 }

--- a/tests/TestCase/Controller/Admin/SyncControllerTest.php
+++ b/tests/TestCase/Controller/Admin/SyncControllerTest.php
@@ -1,0 +1,63 @@
+<?php
+declare(strict_types=1);
+
+namespace TinyAuthBackend\Test\TestCase\Controller\Admin;
+
+use Cake\ORM\TableRegistry;
+use Cake\TestSuite\IntegrationTestTrait;
+use Cake\TestSuite\TestCase;
+
+class SyncControllerTest extends TestCase {
+
+	use IntegrationTestTrait;
+
+	protected array $fixtures = [
+		'plugin.TinyAuthBackend.TinyAuthControllers',
+		'plugin.TinyAuthBackend.TinyAuthActions',
+		'plugin.TinyAuthBackend.TinyAuthResources',
+		'plugin.TinyAuthBackend.TinyAuthResourceAbilities',
+	];
+
+	public function setUp(): void {
+		parent::setUp();
+
+		$this->loadPlugins(['TinyAuthBackend']);
+	}
+
+	public function testControllersIndex(): void {
+		$this->get(['prefix' => 'Admin', 'plugin' => 'TinyAuthBackend', 'controller' => 'Sync', 'action' => 'controllers']);
+
+		$this->assertResponseCode(200);
+		$this->assertResponseContains('Sync');
+	}
+
+	public function testControllersSync(): void {
+		$this->post(['prefix' => 'Admin', 'plugin' => 'TinyAuthBackend', 'controller' => 'Sync', 'action' => 'controllers'], [
+			'add_new' => '1',
+			'add_actions' => '1',
+		]);
+
+		$this->assertResponseCode(302);
+		$this->assertGreaterThan(0, TableRegistry::getTableLocator()->get('tinyauth_controllers')->find()->count());
+		$this->assertGreaterThan(0, TableRegistry::getTableLocator()->get('tinyauth_actions')->find()->count());
+	}
+
+	public function testResourcesIndex(): void {
+		$this->get(['prefix' => 'Admin', 'plugin' => 'TinyAuthBackend', 'controller' => 'Sync', 'action' => 'resources']);
+
+		$this->assertResponseCode(200);
+		$this->assertResponseContains('Sync');
+	}
+
+	public function testResourcesSync(): void {
+		$this->post(['prefix' => 'Admin', 'plugin' => 'TinyAuthBackend', 'controller' => 'Sync', 'action' => 'resources'], [
+			'add_new' => '1',
+			'add_abilities' => '1',
+		]);
+
+		$this->assertResponseCode(302);
+		$this->assertGreaterThan(0, TableRegistry::getTableLocator()->get('tinyauth_resources')->find()->count());
+		$this->assertGreaterThan(0, TableRegistry::getTableLocator()->get('tinyauth_resource_abilities')->find()->count());
+	}
+
+}

--- a/tests/TestCase/Policy/TestIdentity.php
+++ b/tests/TestCase/Policy/TestIdentity.php
@@ -1,0 +1,49 @@
+<?php
+declare(strict_types=1);
+
+namespace TinyAuthBackend\Test\TestCase\Policy;
+
+use ArrayAccess;
+use Authorization\IdentityInterface;
+use Authorization\Policy\ResultInterface;
+use BadMethodCallException;
+use Cake\Datasource\EntityInterface;
+
+class TestIdentity implements IdentityInterface {
+
+	public function __construct(protected EntityInterface&ArrayAccess $data) {
+	}
+
+	public function can(string $action, mixed $resource): bool {
+		return false;
+	}
+
+	public function canResult(string $action, mixed $resource): ResultInterface {
+		throw new BadMethodCallException('Not implemented for this test double.');
+	}
+
+	public function applyScope(string $action, mixed $resource, mixed ...$optionalArgs): mixed {
+		return $resource;
+	}
+
+	public function getOriginalData(): ArrayAccess|array {
+		return $this->data;
+	}
+
+	public function offsetExists(mixed $offset): bool {
+		return $this->data->offsetExists($offset);
+	}
+
+	public function offsetGet(mixed $offset): mixed {
+		return $this->data->offsetGet($offset);
+	}
+
+	public function offsetSet(mixed $offset, mixed $value): void {
+		$this->data->offsetSet($offset, $value);
+	}
+
+	public function offsetUnset(mixed $offset): void {
+		$this->data->offsetUnset($offset);
+	}
+
+}

--- a/tests/TestCase/Policy/TinyAuthPolicyTest.php
+++ b/tests/TestCase/Policy/TinyAuthPolicyTest.php
@@ -3,18 +3,16 @@ declare(strict_types=1);
 
 namespace TinyAuthBackend\Test\TestCase\Policy;
 
-use ArrayAccess;
-use Authorization\IdentityInterface;
-use Authorization\Policy\ResultInterface;
 use Cake\Core\Configure;
-use Cake\Datasource\EntityInterface;
 use Cake\ORM\Entity;
-use Cake\ORM\TableRegistry;
 use Cake\TestSuite\TestCase;
 use TestApp\Model\Entity\Article;
 use TinyAuthBackend\Policy\TinyAuthPolicy;
+use TinyAuthBackend\Test\TestSuite\DatabaseTestTrait;
 
 class TinyAuthPolicyTest extends TestCase {
+
+	use DatabaseTestTrait;
 
 	protected array $fixtures = [
 		'plugin.TinyAuthBackend.TinyAuthRoles',
@@ -85,49 +83,6 @@ class TinyAuthPolicyTest extends TestCase {
 		$result = $policy->before($identity, new Article(), 'edit');
 
 		$this->assertTrue($result);
-	}
-
-	protected function insertRow(string $table, array $data): void {
-		TableRegistry::getTableLocator()->get($table)->getConnection()->insert($table, $data);
-	}
-
-}
-
-class TestIdentity implements IdentityInterface {
-
-	public function __construct(protected EntityInterface&ArrayAccess $data) {
-	}
-
-	public function can(string $action, mixed $resource): bool {
-		return false;
-	}
-
-	public function canResult(string $action, mixed $resource): ResultInterface {
-		throw new \BadMethodCallException('Not implemented for this test double.');
-	}
-
-	public function applyScope(string $action, mixed $resource, mixed ...$optionalArgs): mixed {
-		return $resource;
-	}
-
-	public function getOriginalData(): ArrayAccess|array {
-		return $this->data;
-	}
-
-	public function offsetExists(mixed $offset): bool {
-		return $this->data->offsetExists($offset);
-	}
-
-	public function offsetGet(mixed $offset): mixed {
-		return $this->data->offsetGet($offset);
-	}
-
-	public function offsetSet(mixed $offset, mixed $value): void {
-		$this->data->offsetSet($offset, $value);
-	}
-
-	public function offsetUnset(mixed $offset): void {
-		$this->data->offsetUnset($offset);
 	}
 
 }

--- a/tests/TestCase/Policy/TinyAuthPolicyTest.php
+++ b/tests/TestCase/Policy/TinyAuthPolicyTest.php
@@ -1,0 +1,133 @@
+<?php
+declare(strict_types=1);
+
+namespace TinyAuthBackend\Test\TestCase\Policy;
+
+use ArrayAccess;
+use Authorization\IdentityInterface;
+use Authorization\Policy\ResultInterface;
+use Cake\Core\Configure;
+use Cake\Datasource\EntityInterface;
+use Cake\ORM\Entity;
+use Cake\ORM\TableRegistry;
+use Cake\TestSuite\TestCase;
+use TestApp\Model\Entity\Article;
+use TinyAuthBackend\Policy\TinyAuthPolicy;
+
+class TinyAuthPolicyTest extends TestCase {
+
+	protected array $fixtures = [
+		'plugin.TinyAuthBackend.TinyAuthRoles',
+		'plugin.TinyAuthBackend.TinyAuthResources',
+		'plugin.TinyAuthBackend.TinyAuthResourceAbilities',
+		'plugin.TinyAuthBackend.TinyAuthResourceAcl',
+	];
+
+	public function setUp(): void {
+		parent::setUp();
+
+		Configure::write('TinyAuthBackend.roleHierarchy', false);
+		Configure::write('TinyAuthBackend.multiRole', false);
+		Configure::delete('TinyAuthBackend.superAdminRole');
+		Configure::delete('TinyAuth.superAdminRole');
+
+		$this->insertRow('tinyauth_roles', [
+			'id' => 1,
+			'name' => 'Administrator',
+			'alias' => 'admin',
+			'parent_id' => null,
+			'sort_order' => 100,
+		]);
+		$this->insertRow('tinyauth_roles', [
+			'id' => 2,
+			'name' => 'Root',
+			'alias' => 'root',
+			'parent_id' => null,
+			'sort_order' => 200,
+		]);
+		$this->insertRow('tinyauth_resources', [
+			'id' => 1,
+			'name' => 'Article',
+			'entity_class' => 'TestApp\Model\Entity\Article',
+			'table_name' => 'articles',
+		]);
+		$this->insertRow('tinyauth_resource_abilities', [
+			'id' => 1,
+			'resource_id' => 1,
+			'name' => 'edit',
+			'description' => null,
+		]);
+		$this->insertRow('tinyauth_resource_acl', [
+			'id' => 1,
+			'resource_ability_id' => 1,
+			'role_id' => 1,
+			'type' => 'allow',
+			'scope_id' => null,
+		]);
+	}
+
+	public function testCanEditUsesSyncedResourceName(): void {
+		$policy = new TinyAuthPolicy();
+		$user = new Entity(['id' => 99, 'role_id' => 1]);
+		$article = new Article(['id' => 5, 'user_id' => 99]);
+
+		$result = $policy->canEdit($user, $article);
+
+		$this->assertTrue($result);
+	}
+
+	public function testBeforeUsesConfiguredSuperAdminRole(): void {
+		Configure::write('TinyAuth.superAdminRole', 'root');
+
+		$policy = new TinyAuthPolicy();
+		$identity = new TestIdentity(new Entity(['id' => 1, 'role_id' => 2]));
+
+		$result = $policy->before($identity, new Article(), 'edit');
+
+		$this->assertTrue($result);
+	}
+
+	protected function insertRow(string $table, array $data): void {
+		TableRegistry::getTableLocator()->get($table)->getConnection()->insert($table, $data);
+	}
+
+}
+
+class TestIdentity implements IdentityInterface {
+
+	public function __construct(protected EntityInterface&ArrayAccess $data) {
+	}
+
+	public function can(string $action, mixed $resource): bool {
+		return false;
+	}
+
+	public function canResult(string $action, mixed $resource): ResultInterface {
+		throw new \BadMethodCallException('Not implemented for this test double.');
+	}
+
+	public function applyScope(string $action, mixed $resource, mixed ...$optionalArgs): mixed {
+		return $resource;
+	}
+
+	public function getOriginalData(): ArrayAccess|array {
+		return $this->data;
+	}
+
+	public function offsetExists(mixed $offset): bool {
+		return $this->data->offsetExists($offset);
+	}
+
+	public function offsetGet(mixed $offset): mixed {
+		return $this->data->offsetGet($offset);
+	}
+
+	public function offsetSet(mixed $offset, mixed $value): void {
+		$this->data->offsetSet($offset, $value);
+	}
+
+	public function offsetUnset(mixed $offset): void {
+		$this->data->offsetUnset($offset);
+	}
+
+}

--- a/tests/TestCase/Service/HierarchyServiceTest.php
+++ b/tests/TestCase/Service/HierarchyServiceTest.php
@@ -1,0 +1,72 @@
+<?php
+declare(strict_types=1);
+
+namespace TinyAuthBackend\Test\TestCase\Service;
+
+use Cake\ORM\TableRegistry;
+use Cake\TestSuite\TestCase;
+use TinyAuthBackend\Service\HierarchyService;
+
+class HierarchyServiceTest extends TestCase {
+
+	protected array $fixtures = [
+		'plugin.TinyAuthBackend.TinyAuthRoles',
+	];
+
+	public function setUp(): void {
+		parent::setUp();
+
+		$this->insertRow('tinyauth_roles', [
+			'id' => 1,
+			'name' => 'Administrator',
+			'alias' => 'admin',
+			'parent_id' => null,
+			'sort_order' => 30,
+		]);
+		$this->insertRow('tinyauth_roles', [
+			'id' => 2,
+			'name' => 'Moderator',
+			'alias' => 'moderator',
+			'parent_id' => 1,
+			'sort_order' => 20,
+		]);
+		$this->insertRow('tinyauth_roles', [
+			'id' => 3,
+			'name' => 'User',
+			'alias' => 'user',
+			'parent_id' => 2,
+			'sort_order' => 10,
+		]);
+	}
+
+	public function testApplyInheritancePromotesPermissionsToParents(): void {
+		$service = new HierarchyService();
+		$acl = [
+			'Articles' => [
+				'plugin' => null,
+				'prefix' => null,
+				'controller' => 'Articles',
+				'allow' => [
+					'edit' => ['user' => 3],
+				],
+				'deny' => [],
+			],
+		];
+
+		$result = $service->applyInheritance($acl, [
+			'admin' => 1,
+			'moderator' => 2,
+			'user' => 3,
+		]);
+
+		$this->assertSame(
+			['user' => 3, 'moderator' => 2, 'admin' => 1],
+			$result['Articles']['allow']['edit'],
+		);
+	}
+
+	protected function insertRow(string $table, array $data): void {
+		TableRegistry::getTableLocator()->get($table)->getConnection()->insert($table, $data);
+	}
+
+}

--- a/tests/TestCase/Service/HierarchyServiceTest.php
+++ b/tests/TestCase/Service/HierarchyServiceTest.php
@@ -3,11 +3,13 @@ declare(strict_types=1);
 
 namespace TinyAuthBackend\Test\TestCase\Service;
 
-use Cake\ORM\TableRegistry;
 use Cake\TestSuite\TestCase;
 use TinyAuthBackend\Service\HierarchyService;
+use TinyAuthBackend\Test\TestSuite\DatabaseTestTrait;
 
 class HierarchyServiceTest extends TestCase {
+
+	use DatabaseTestTrait;
 
 	protected array $fixtures = [
 		'plugin.TinyAuthBackend.TinyAuthRoles',
@@ -63,10 +65,6 @@ class HierarchyServiceTest extends TestCase {
 			['user' => 3, 'moderator' => 2, 'admin' => 1],
 			$result['Articles']['allow']['edit'],
 		);
-	}
-
-	protected function insertRow(string $table, array $data): void {
-		TableRegistry::getTableLocator()->get($table)->getConnection()->insert($table, $data);
 	}
 
 }

--- a/tests/TestCase/Service/RoleSourceServiceTest.php
+++ b/tests/TestCase/Service/RoleSourceServiceTest.php
@@ -1,0 +1,45 @@
+<?php
+declare(strict_types=1);
+
+namespace TinyAuthBackend\Test\TestCase\Service;
+
+use Cake\Core\Configure;
+use Cake\ORM\TableRegistry;
+use Cake\TestSuite\TestCase;
+use TinyAuthBackend\Service\RoleSourceService;
+
+class RoleSourceServiceTest extends TestCase {
+
+	protected array $fixtures = [
+		'plugin.TinyAuthBackend.TinyAuthRoles',
+	];
+
+	public function setUp(): void {
+		parent::setUp();
+
+		(new RoleSourceService())->clearCache();
+	}
+
+	public function tearDown(): void {
+		(new RoleSourceService())->clearCache();
+		Configure::delete('TinyAuthBackend.roleSource');
+
+		parent::tearDown();
+	}
+
+	public function testExternalRoleSourceSyncsShadowRows(): void {
+		Configure::write('TinyAuthBackend.roleSource', ['editor' => 10, 'manager' => 20]);
+		(new RoleSourceService())->clearCache();
+
+		$roles = (new RoleSourceService())->getRoles();
+
+		$this->assertSame(['editor' => 10, 'manager' => 20], $roles);
+		$this->assertSame(1, $this->countRows('tinyauth_roles', ['id' => 10, 'alias' => 'editor']));
+		$this->assertSame(1, $this->countRows('tinyauth_roles', ['id' => 20, 'alias' => 'manager']));
+	}
+
+	protected function countRows(string $table, array $conditions): int {
+		return TableRegistry::getTableLocator()->get($table)->find()->where($conditions)->count();
+	}
+
+}

--- a/tests/TestCase/Service/TinyAuthServiceTest.php
+++ b/tests/TestCase/Service/TinyAuthServiceTest.php
@@ -1,0 +1,147 @@
+<?php
+declare(strict_types=1);
+
+namespace TinyAuthBackend\Test\TestCase\Service;
+
+use Cake\Core\Configure;
+use Cake\ORM\Entity;
+use Cake\ORM\TableRegistry;
+use Cake\TestSuite\TestCase;
+use TestApp\Model\Entity\Article;
+use TinyAuthBackend\Service\TinyAuthService;
+
+class TinyAuthServiceTest extends TestCase {
+
+	protected array $fixtures = [
+		'plugin.TinyAuthBackend.TinyAuthRoles',
+		'plugin.TinyAuthBackend.TinyAuthResources',
+		'plugin.TinyAuthBackend.TinyAuthResourceAbilities',
+		'plugin.TinyAuthBackend.TinyAuthResourceAcl',
+		'plugin.TinyAuthBackend.TinyAuthScopes',
+	];
+
+	public function setUp(): void {
+		parent::setUp();
+
+		Configure::write('TinyAuthBackend.roleHierarchy', true);
+		Configure::write('TinyAuthBackend.multiRole', false);
+
+		$this->insertRow('tinyauth_roles', [
+			'id' => 1,
+			'name' => 'Administrator',
+			'alias' => 'admin',
+			'parent_id' => null,
+			'sort_order' => 30,
+		]);
+		$this->insertRow('tinyauth_roles', [
+			'id' => 2,
+			'name' => 'Moderator',
+			'alias' => 'moderator',
+			'parent_id' => 1,
+			'sort_order' => 20,
+		]);
+		$this->insertRow('tinyauth_roles', [
+			'id' => 3,
+			'name' => 'User',
+			'alias' => 'user',
+			'parent_id' => 2,
+			'sort_order' => 10,
+		]);
+		$this->insertRow('tinyauth_resources', [
+			'id' => 1,
+			'name' => 'Article',
+			'entity_class' => 'TestApp\Model\Entity\Article',
+			'table_name' => 'articles',
+		]);
+		$this->insertRow('tinyauth_resource_abilities', [
+			'id' => 1,
+			'resource_id' => 1,
+			'name' => 'edit',
+			'description' => null,
+		]);
+		$this->insertRow('tinyauth_scopes', [
+			'id' => 1,
+			'name' => 'own',
+			'description' => 'Own records',
+			'entity_field' => 'user_id',
+			'user_field' => 'id',
+		]);
+	}
+
+	public function testInheritedAllowComesFromDescendantRoles(): void {
+		$this->insertRow('tinyauth_resource_acl', [
+			'id' => 1,
+			'resource_ability_id' => 1,
+			'role_id' => 3,
+			'type' => 'allow',
+			'scope_id' => null,
+		]);
+
+		$service = new TinyAuthService();
+
+		$result = $service->canAccess(['admin'], 'Article', 'edit', new Article(['user_id' => 9]), new Entity(['id' => 9]));
+
+		$this->assertTrue($result);
+	}
+
+	public function testDirectDenyBeatsInheritedAllow(): void {
+		$this->insertRow('tinyauth_resource_acl', [
+			'id' => 1,
+			'resource_ability_id' => 1,
+			'role_id' => 3,
+			'type' => 'allow',
+			'scope_id' => null,
+		]);
+		$this->insertRow('tinyauth_resource_acl', [
+			'id' => 2,
+			'resource_ability_id' => 1,
+			'role_id' => 1,
+			'type' => 'deny',
+			'scope_id' => null,
+		]);
+
+		$service = new TinyAuthService();
+
+		$result = $service->canAccess(['admin'], 'Article', 'edit', new Article(['user_id' => 9]), new Entity(['id' => 9]));
+
+		$this->assertFalse($result);
+	}
+
+	public function testGetScopeConditionUsesInheritedRules(): void {
+		$this->insertRow('tinyauth_resource_acl', [
+			'id' => 1,
+			'resource_ability_id' => 1,
+			'role_id' => 3,
+			'type' => 'allow',
+			'scope_id' => 1,
+		]);
+
+		$service = new TinyAuthService();
+
+		$result = $service->getScopeCondition(['admin'], 'Article', 'edit', new Entity(['id' => 42]));
+
+		$this->assertSame(['user_id' => 42], $result);
+	}
+
+	public function testCanAccessResourceUsesEntityBasename(): void {
+		$this->insertRow('tinyauth_resource_acl', [
+			'id' => 1,
+			'resource_ability_id' => 1,
+			'role_id' => 1,
+			'type' => 'allow',
+			'scope_id' => null,
+		]);
+
+		$service = new TinyAuthService();
+		$user = new Entity(['id' => 7, 'role_id' => 1]);
+
+		$result = $service->canAccessResource($user, new Article(['user_id' => 7]), 'edit');
+
+		$this->assertTrue($result);
+	}
+
+	protected function insertRow(string $table, array $data): void {
+		TableRegistry::getTableLocator()->get($table)->getConnection()->insert($table, $data);
+	}
+
+}

--- a/tests/TestCase/Service/TinyAuthServiceTest.php
+++ b/tests/TestCase/Service/TinyAuthServiceTest.php
@@ -140,6 +140,59 @@ class TinyAuthServiceTest extends TestCase {
 		$this->assertTrue($result);
 	}
 
+	public function testCanAccessResourceUsesEntityClassToAvoidNameCollisions(): void {
+		$this->insertRow('tinyauth_resources', [
+			'id' => 2,
+			'name' => 'Article',
+			'entity_class' => 'Other\\Plugin\\Model\\Entity\\Article',
+			'table_name' => 'other_articles',
+		]);
+		$this->insertRow('tinyauth_resource_abilities', [
+			'id' => 2,
+			'resource_id' => 2,
+			'name' => 'edit',
+			'description' => null,
+		]);
+		$this->insertRow('tinyauth_resource_acl', [
+			'id' => 1,
+			'resource_ability_id' => 2,
+			'role_id' => 1,
+			'type' => 'deny',
+			'scope_id' => null,
+		]);
+		$this->insertRow('tinyauth_resource_acl', [
+			'id' => 2,
+			'resource_ability_id' => 1,
+			'role_id' => 1,
+			'type' => 'allow',
+			'scope_id' => null,
+		]);
+
+		$service = new TinyAuthService();
+		$user = new Entity(['id' => 7, 'role_id' => 1]);
+
+		$result = $service->canAccessResource($user, new Article(['user_id' => 7]), 'edit');
+
+		$this->assertTrue($result);
+	}
+
+	public function testGetUserRolesUsesConfiguredMultiRoleProperty(): void {
+		Configure::write('TinyAuthBackend.multiRole', true);
+		Configure::write('TinyAuthBackend.rolesTable', 'memberships');
+
+		$service = new TinyAuthService();
+		$user = new Entity([
+			'memberships' => [
+				new Entity(['alias' => 'user']),
+				new Entity(['alias' => 'admin']),
+			],
+		]);
+
+		$result = $service->getUserRoles($user);
+
+		$this->assertSame(['user', 'admin'], $result);
+	}
+
 	protected function insertRow(string $table, array $data): void {
 		TableRegistry::getTableLocator()->get($table)->getConnection()->insert($table, $data);
 	}

--- a/tests/TestCase/Service/TinyAuthServiceTest.php
+++ b/tests/TestCase/Service/TinyAuthServiceTest.php
@@ -5,12 +5,14 @@ namespace TinyAuthBackend\Test\TestCase\Service;
 
 use Cake\Core\Configure;
 use Cake\ORM\Entity;
-use Cake\ORM\TableRegistry;
 use Cake\TestSuite\TestCase;
 use TestApp\Model\Entity\Article;
 use TinyAuthBackend\Service\TinyAuthService;
+use TinyAuthBackend\Test\TestSuite\DatabaseTestTrait;
 
 class TinyAuthServiceTest extends TestCase {
+
+	use DatabaseTestTrait;
 
 	protected array $fixtures = [
 		'plugin.TinyAuthBackend.TinyAuthRoles',
@@ -191,10 +193,6 @@ class TinyAuthServiceTest extends TestCase {
 		$result = $service->getUserRoles($user);
 
 		$this->assertSame(['user', 'admin'], $result);
-	}
-
-	protected function insertRow(string $table, array $data): void {
-		TableRegistry::getTableLocator()->get($table)->getConnection()->insert($table, $data);
 	}
 
 }

--- a/tests/TestSuite/DatabaseTestTrait.php
+++ b/tests/TestSuite/DatabaseTestTrait.php
@@ -27,14 +27,15 @@ trait DatabaseTestTrait {
 
 	protected function syncPrimaryKeySequence(Table $tableObject, string $table): void {
 		$connection = $tableObject->getConnection();
-		if (!($connection->getDriver() instanceof Postgres)) {
+		$driver = $connection->getDriver();
+		if (!($driver instanceof Postgres)) {
 			return;
 		}
 		if (!$tableObject->getSchema()->hasColumn('id')) {
 			return;
 		}
 
-		$quotedTable = $connection->quoteIdentifier($table);
+		$quotedTable = $driver->quoteIdentifier($table);
 		$connection->execute(sprintf(
 			"SELECT setval(pg_get_serial_sequence('%s', 'id'), COALESCE((SELECT MAX(id) FROM %s), 1), true)",
 			$table,

--- a/tests/TestSuite/DatabaseTestTrait.php
+++ b/tests/TestSuite/DatabaseTestTrait.php
@@ -1,0 +1,45 @@
+<?php
+declare(strict_types=1);
+
+namespace TinyAuthBackend\Test\TestSuite;
+
+use Cake\Database\Driver\Postgres;
+use Cake\ORM\Table;
+use Cake\ORM\TableRegistry;
+
+trait DatabaseTestTrait {
+
+	protected function insertRow(string $table, array $data): void {
+		$tableObject = TableRegistry::getTableLocator()->get($table);
+		$entity = $tableObject->newEntity($data, [
+			'accessibleFields' => ['*' => true],
+		]);
+		$tableObject->saveOrFail($entity, ['checkRules' => false]);
+
+		if (array_key_exists('id', $data)) {
+			$this->syncPrimaryKeySequence($tableObject, $table);
+		}
+	}
+
+	protected function countRows(string $table, array $conditions): int {
+		return TableRegistry::getTableLocator()->get($table)->find()->where($conditions)->count();
+	}
+
+	protected function syncPrimaryKeySequence(Table $tableObject, string $table): void {
+		$connection = $tableObject->getConnection();
+		if (!($connection->getDriver() instanceof Postgres)) {
+			return;
+		}
+		if (!$tableObject->getSchema()->hasColumn('id')) {
+			return;
+		}
+
+		$quotedTable = $connection->quoteIdentifier($table);
+		$connection->execute(sprintf(
+			"SELECT setval(pg_get_serial_sequence('%s', 'id'), COALESCE((SELECT MAX(id) FROM %s), 1), true)",
+			$table,
+			$quotedTable,
+		));
+	}
+
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -15,6 +15,26 @@ use TinyAuthBackend\TinyAuthBackendPlugin;
 if (!defined('DS')) {
 	define('DS', DIRECTORY_SEPARATOR);
 }
+
+if (!function_exists('findVendorPath')) {
+	/**
+	 * @param string $startDir
+	 * @return string|null
+	 */
+	function findVendorPath(string $startDir): ?string {
+		$dir = $startDir;
+		while ($dir !== dirname($dir)) {
+			$autoload = $dir . DS . 'vendor' . DS . 'autoload.php';
+			if (file_exists($autoload)) {
+				return $dir . DS . 'vendor';
+			}
+			$dir = dirname($dir);
+		}
+
+		return null;
+	}
+}
+
 define('ROOT', dirname(__DIR__));
 define('APP_DIR', 'src');
 
@@ -33,11 +53,20 @@ define('TESTS', ROOT . DS . 'tests' . DS);
 define('LOGS', TMP . 'logs' . DS);
 define('CACHE', TMP . 'cache' . DS);
 
-define('CAKE_CORE_INCLUDE_PATH', ROOT . '/vendor/cakephp/cakephp');
+$vendorPath = findVendorPath(ROOT);
+if ($vendorPath === null) {
+	throw new RuntimeException('Unable to locate Composer vendor directory for tests.');
+}
+
+define('CAKE_CORE_INCLUDE_PATH', $vendorPath . '/cakephp/cakephp');
 define('CORE_PATH', CAKE_CORE_INCLUDE_PATH . DS);
 define('CAKE', CORE_PATH . APP_DIR . DS);
 
-require dirname(__DIR__) . '/vendor/autoload.php';
+/** @var \Composer\Autoload\ClassLoader $autoloader */
+$autoloader = require $vendorPath . '/autoload.php';
+$autoloader->addPsr4('TinyAuthBackend\\Test\\', ROOT . DS . 'tests' . DS);
+$autoloader->addPsr4('TestApp\\', ROOT . DS . 'tests' . DS . 'test_app' . DS . 'src' . DS);
+
 require CORE_PATH . 'config/bootstrap.php';
 require CAKE_CORE_INCLUDE_PATH . '/src/functions.php';
 

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -62,7 +62,6 @@ define('CAKE_CORE_INCLUDE_PATH', $vendorPath . '/cakephp/cakephp');
 define('CORE_PATH', CAKE_CORE_INCLUDE_PATH . DS);
 define('CAKE', CORE_PATH . APP_DIR . DS);
 
-/** @var \Composer\Autoload\ClassLoader $autoloader */
 $autoloader = require $vendorPath . '/autoload.php';
 $autoloader->addPsr4('TinyAuthBackend\\Test\\', ROOT . DS . 'tests' . DS);
 $autoloader->addPsr4('TestApp\\', ROOT . DS . 'tests' . DS . 'test_app' . DS . 'src' . DS);

--- a/tests/config/routes.php
+++ b/tests/config/routes.php
@@ -10,16 +10,16 @@ Router::defaultRouteClass(DashedRoute::class);
 
 // Match the plugin routes from TinyAuthBackendPlugin
 // Use prefix scope so fallbacks work correctly with Admin prefix
-Router::plugin('TinyAuthBackend', ['path' => '/admin/tinyauth'], function (RouteBuilder $builder): void {
+Router::plugin('TinyAuthBackend', ['path' => '/admin/auth'], function (RouteBuilder $builder): void {
 	$builder->prefix('Admin', function (RouteBuilder $prefixBuilder): void {
-		$prefixBuilder->connect('/', ['controller' => 'Acl', 'action' => 'index']);
+		$prefixBuilder->connect('/', ['controller' => 'Dashboard', 'action' => 'index']);
+		$prefixBuilder->connect('/dashboard', ['controller' => 'Dashboard', 'action' => 'index']);
 		$prefixBuilder->connect('/acl', ['controller' => 'Acl', 'action' => 'index']);
 		$prefixBuilder->connect('/allow', ['controller' => 'Allow', 'action' => 'index']);
 		$prefixBuilder->connect('/roles', ['controller' => 'Roles', 'action' => 'index']);
 		$prefixBuilder->connect('/resources', ['controller' => 'Resources', 'action' => 'index']);
 		$prefixBuilder->connect('/scopes', ['controller' => 'Scopes', 'action' => 'index']);
-		$prefixBuilder->connect('/sync', ['controller' => 'Sync', 'action' => 'index']);
-		// Explicit routes for Sync controller actions
+		$prefixBuilder->connect('/sync', ['controller' => 'Sync', 'action' => 'controllers']);
 		$prefixBuilder->connect('/sync/controllers', ['controller' => 'Sync', 'action' => 'controllers']);
 		$prefixBuilder->connect('/sync/resources', ['controller' => 'Sync', 'action' => 'resources']);
 		$prefixBuilder->fallbacks();

--- a/tests/test_app/src/Model/Entity/Article.php
+++ b/tests/test_app/src/Model/Entity/Article.php
@@ -1,0 +1,9 @@
+<?php
+declare(strict_types=1);
+
+namespace TestApp\Model\Entity;
+
+use Cake\ORM\Entity;
+
+class Article extends Entity {
+}


### PR DESCRIPTION
## Summary
- fix resource policy/resource-name matching and configurable super-admin bypass
- align ACL/resource hierarchy behavior so higher roles inherit lower-role permissions and direct rules win
- add regression tests and refresh docs with adapter-only and native CakePHP auth strategies

## Testing
- /tmp/cakephp-tinyauth-demo/vendor/bin/phpunit
- /tmp/cakephp-tinyauth-demo/vendor/bin/phpstan analyse --no-progress