### PR TITLE
Code quality improvements

### DIFF
--- a/config/bootstrap.php
+++ b/config/bootstrap.php
@@ -31,4 +31,13 @@ Configure::write('TinyAuthBackend', [
 	//   callable - Function returning array of roles
 	// Example callable: fn() => TableRegistry::get('Roles')->find('list')->toArray()
 	'roleSource' => null,
+
+	// Resource namespace filter for the admin panel
+	// Only show resources matching this namespace prefix (e.g., 'App\\' to exclude plugin entities)
+	// Set to null or empty string to show all resources
+	'resourceNamespaceFilter' => 'App\\',
+
+	// Plugins to exclude from ACL controller tree in admin panel
+	// These plugins won't appear in the permission management UI
+	'excludedPlugins' => ['DebugKit', 'TinyAuthBackend'],
 ]);

--- a/src/Model/Table/AclRulesTable.php
+++ b/src/Model/Table/AclRulesTable.php
@@ -24,13 +24,6 @@ class AclRulesTable extends Table {
 	use ValidationTrait;
 
 	/**
-	 * @var array<string, string>
-	 */
-	public array $order = ['created' => 'DESC'];
-
-	protected ?string $_table = 'tiny_auth_acl_rules';
-
-	/**
 	 * Initialize method
 	 *
 	 * @param array<string, mixed> $config The configuration for the Table.
@@ -40,6 +33,7 @@ class AclRulesTable extends Table {
 	public function initialize(array $config): void {
 		parent::initialize($config);
 
+		$this->setTable('tiny_auth_acl_rules');
 		$this->addBehavior('Timestamp');
 	}
 

--- a/src/Model/Table/AllowRulesTable.php
+++ b/src/Model/Table/AllowRulesTable.php
@@ -24,13 +24,6 @@ class AllowRulesTable extends Table {
 	use ValidationTrait;
 
 	/**
-	 * @var array<string, string>
-	 */
-	public array $order = ['created' => 'DESC'];
-
-	protected ?string $_table = 'tiny_auth_allow_rules';
-
-	/**
 	 * Initialize method
 	 *
 	 * @param array<string, mixed> $config The configuration for the Table.
@@ -40,6 +33,7 @@ class AllowRulesTable extends Table {
 	public function initialize(array $config): void {
 		parent::initialize($config);
 
+		$this->setTable('tiny_auth_allow_rules');
 		$this->addBehavior('Timestamp');
 	}
 

--- a/src/Utility/RulePath.php
+++ b/src/Utility/RulePath.php
@@ -13,15 +13,15 @@ class RulePath {
 	public static function parse(string $path): array {
 		$controller = $path;
 		$action = null;
-		if (strpos($controller, '::') !== false) {
+		if (str_contains($controller, '::')) {
 			[$controller, $action] = explode('::', $controller);
 		}
 
 		$prefix = $plugin = null;
-		if (strpos($controller, '.') !== false) {
+		if (str_contains($controller, '.')) {
 			[$plugin, $controller] = explode('.', $controller, 2);
 		}
-		if (strpos($controller, '/') !== false) {
+		if (str_contains($controller, '/')) {
 			$pos = (int)strrpos($controller, '/');
 			$prefix = substr($controller, 0, $pos);
 			$controller = substr($controller, $pos + 1);

--- a/tests/TestCase/Controller/Admin/RolesControllerTest.php
+++ b/tests/TestCase/Controller/Admin/RolesControllerTest.php
@@ -37,9 +37,9 @@ class RolesControllerTest extends TestCase {
 		$this->loadPlugins(['TinyAuthBackend']);
 
 		Configure::write('Roles', [
-			'user' => ROLE_USER,
-			'moderator' => ROLE_MODERATOR,
-			'admin' => ROLE_ADMIN,
+			'user' => 3,
+			'moderator' => 2,
+			'admin' => 1,
 		]);
 	}
 


### PR DESCRIPTION
## Summary
- Document `resourceNamespaceFilter` and `excludedPlugins` config options in bootstrap.php
- Fix undefined constants in RolesControllerTest (replaced `ROLE_USER`, `ROLE_MODERATOR`, `ROLE_ADMIN` with literal values)
- Update RulePath to use `str_contains()` instead of deprecated `strpos()` pattern
- Remove deprecated `$order` property and `$_table` from legacy table classes (use `setTable()` instead)