### PR TITLE
Show inherited ACL permissions in matrix

### DIFF
--- a/src/Controller/Admin/AclController.php
+++ b/src/Controller/Admin/AclController.php
@@ -3,8 +3,10 @@ declare(strict_types=1);
 
 namespace TinyAuthBackend\Controller\Admin;
 
+use Cake\Core\Configure;
 use Cake\Http\Exception\BadRequestException;
 use Cake\Http\Response;
+use TinyAuthBackend\Service\HierarchyService;
 use TinyAuthBackend\Service\RoleSourceService;
 
 /**
@@ -32,21 +34,7 @@ class AclController extends AppController {
 		if ($controllerId) {
 			$selectedController = $controllersTable->get($controllerId, contain: ['Actions']);
 			$actions = $selectedController->actions ?? [];
-
-			// Load permissions for this controller's actions
-			$permissionsTable = $this->fetchTable('TinyAuthBackend.AclPermissions');
-			$actionIds = array_map(fn ($a) => $a->id, $actions);
-
-			if ($actionIds) {
-				$perms = $permissionsTable->find()
-					->where(['action_id IN' => $actionIds])
-					->all();
-
-				/** @var \TinyAuthBackend\Model\Entity\AclPermission $perm */
-				foreach ($perms as $perm) {
-					$permissions[$perm->action_id][$perm->role_id] = $perm->type;
-				}
-			}
+			$permissions = $this->buildCellStates($roles, array_map(static fn ($action) => (int)$action->id, $actions));
 		}
 
 		$this->set(compact('tree', 'roles', 'selectedController', 'actions', 'permissions'));
@@ -103,9 +91,13 @@ class AclController extends AppController {
 			}
 		}
 
+		$roles = (new RoleSourceService())->getRoleEntities();
+		$permissions = $this->buildCellStates($roles, [$actionId]);
+		$cell = $permissions[$actionId][$roleId] ?? $this->buildCellState($actionId, $roleId, null, false);
+
 		// Return updated cell HTML
 		$this->viewBuilder()->disableAutoLayout();
-		$this->set(compact('actionId', 'roleId', 'type'));
+		$this->set(compact('cell'));
 
 		return $this->render('toggle_cell');
 	}
@@ -147,6 +139,152 @@ class AclController extends AppController {
 		}
 
 		$this->set('results', $results);
+	}
+
+	/**
+	 * @param array<object> $roles
+	 * @param array<int> $actionIds
+	 * @return array<int, array<int, array<string, mixed>>>
+	 */
+	protected function buildCellStates(array $roles, array $actionIds): array {
+		$states = [];
+		if (!$actionIds) {
+			return $states;
+		}
+
+		$permissionsTable = $this->fetchTable('TinyAuthBackend.AclPermissions');
+		$perms = $permissionsTable->find()
+			->where(['action_id IN' => $actionIds])
+			->all();
+
+		$directPermissions = [];
+		/** @var \TinyAuthBackend\Model\Entity\AclPermission $perm */
+		foreach ($perms as $perm) {
+			$directPermissions[$perm->action_id][$perm->role_id] = $perm->type;
+		}
+
+		$inheritedPermissions = $this->buildInheritedPermissions($roles, $actionIds, $directPermissions);
+
+		foreach ($actionIds as $actionId) {
+			foreach ($roles as $role) {
+				$roleId = (int)($role->id ?? 0);
+				if (!$roleId) {
+					continue;
+				}
+
+				$directType = $directPermissions[$actionId][$roleId] ?? null;
+				$isInherited = $inheritedPermissions[$actionId][$roleId] ?? false;
+				$states[$actionId][$roleId] = $this->buildCellState($actionId, $roleId, $directType, $isInherited);
+			}
+		}
+
+		return $states;
+	}
+
+	/**
+	 * @param array<object> $roles
+	 * @param array<int> $actionIds
+	 * @param array<int, array<int, string>> $directPermissions
+	 * @return array<int, array<int, bool>>
+	 */
+	protected function buildInheritedPermissions(array $roles, array $actionIds, array $directPermissions): array {
+		if (!Configure::read('TinyAuthBackend.roleHierarchy')) {
+			return [];
+		}
+
+		$availableRoles = [];
+		$aliasesByRoleId = [];
+		foreach ($roles as $role) {
+			$alias = isset($role->alias) ? (string)$role->alias : '';
+			$roleId = isset($role->id) ? (int)$role->id : 0;
+			if ($alias === '' || !$roleId) {
+				continue;
+			}
+
+			$availableRoles[$alias] = $roleId;
+			$aliasesByRoleId[$roleId] = $alias;
+		}
+
+		$acl = ['selected' => ['allow' => [], 'deny' => []]];
+		foreach ($actionIds as $actionId) {
+			foreach (($directPermissions[$actionId] ?? []) as $roleId => $type) {
+				$alias = $aliasesByRoleId[$roleId] ?? null;
+				if ($alias === null) {
+					continue;
+				}
+				$acl['selected'][$type][(string)$actionId][$alias] = $roleId;
+			}
+		}
+
+		$effectiveAcl = (new HierarchyService())->applyInheritance($acl, $availableRoles);
+		$inheritedPermissions = [];
+		foreach ($actionIds as $actionId) {
+			foreach (($effectiveAcl['selected']['allow'][(string)$actionId] ?? []) as $alias => $roleId) {
+				if (($directPermissions[$actionId][$roleId] ?? null) === 'allow') {
+					continue;
+				}
+				if (($directPermissions[$actionId][$roleId] ?? null) === 'deny') {
+					continue;
+				}
+
+				$inheritedPermissions[$actionId][$roleId] = true;
+			}
+		}
+
+		return $inheritedPermissions;
+	}
+
+	/**
+	 * @param int $actionId
+	 * @param int $roleId
+	 * @param string|null $directType
+	 * @param bool $isInherited
+	 * @return array<string, mixed>
+	 */
+	protected function buildCellState(int $actionId, int $roleId, ?string $directType, bool $isInherited): array {
+		if ($directType === 'deny') {
+			return [
+				'action_id' => $actionId,
+				'role_id' => $roleId,
+				'class' => 'deny',
+				'symbol' => '&#10005;',
+				'next_type' => 'none',
+				'state' => 'deny',
+				'title' => 'Denied',
+			];
+		}
+		if ($directType === 'allow') {
+			return [
+				'action_id' => $actionId,
+				'role_id' => $roleId,
+				'class' => 'allow',
+				'symbol' => '&#9679;',
+				'next_type' => 'deny',
+				'state' => 'allow',
+				'title' => 'Allowed',
+			];
+		}
+		if ($isInherited) {
+			return [
+				'action_id' => $actionId,
+				'role_id' => $roleId,
+				'class' => 'allow inherited',
+				'symbol' => '&#9679;',
+				'next_type' => 'deny',
+				'state' => 'inherited',
+				'title' => 'Inherited permission',
+			];
+		}
+
+		return [
+			'action_id' => $actionId,
+			'role_id' => $roleId,
+			'class' => 'none',
+			'symbol' => '&#9675;',
+			'next_type' => 'allow',
+			'state' => 'none',
+			'title' => 'No permission',
+		];
 	}
 
 }

--- a/templates/Admin/Acl/toggle_cell.php
+++ b/templates/Admin/Acl/toggle_cell.php
@@ -1,18 +1,7 @@
 <?php
 /**
  * @var \Cake\View\View $this
- * @var int $actionId
- * @var int $roleId
- * @var string $type
+ * @var array<string, mixed> $cell
  */
-$symbol = match ($type) {
-	'allow' => '&#9679;',
-	'deny' => '&#10005;',
-	default => '&#9675;',
-};
-?>
-<td id="cell-<?= $actionId ?>-<?= $roleId ?>"
-	class="matrix-cell <?= $type ?>"
-	onclick="window.TinyAuth.togglePermission(<?= $actionId ?>, <?= $roleId ?>, '<?= h($type) ?>')">
-	<?= $symbol ?>
-</td>
+
+echo $this->element('TinyAuthBackend.acl_cell', ['cell' => $cell]);

--- a/templates/Admin/element/acl_cell.php
+++ b/templates/Admin/element/acl_cell.php
@@ -1,0 +1,15 @@
+<?php
+/**
+ * @var \Cake\View\View $this
+ * @var array<string, mixed> $cell
+ */
+?>
+<td id="cell-<?= $cell['action_id'] ?>-<?= $cell['role_id'] ?>"
+	class="matrix-cell <?= h($cell['class']) ?>"
+	data-state="<?= h($cell['state']) ?>"
+	title="<?= h($cell['title']) ?>"
+	hx-post="<?= $this->Url->build(['action' => 'toggle']) ?>"
+	hx-vals='<?= json_encode(['action_id' => $cell['action_id'], 'role_id' => $cell['role_id'], 'type' => $cell['next_type']]) ?>'
+	hx-swap="outerHTML">
+	<?= $cell['symbol'] ?>
+</td>

--- a/templates/Admin/element/matrix.php
+++ b/templates/Admin/element/matrix.php
@@ -3,7 +3,7 @@
  * @var \Cake\View\View $this
  * @var array<\TinyAuthBackend\Model\Entity\Action> $actions
  * @var array<\TinyAuthBackend\Model\Entity\Role> $roles
- * @var array $permissions
+ * @var array<int, array<int, array<string, mixed>>> $permissions
  */
 ?>
 <table class="w-full text-sm">
@@ -25,28 +25,7 @@
 		<tr class="border-b border-gray-100 dark:border-slate-700">
 			<td class="p-2"><?= h($action->name) ?></td>
 			<?php foreach ($roles as $role) { ?>
-				<?php
-				$type = $permissions[$action->id][$role->id] ?? 'none';
-				$symbol = match ($type) {
-					'allow' => '&#9679;',
-					'deny' => '&#10005;',
-					default => '&#9675;',
-				};
-	?>
-				<?php
-				$nextType = match ($type) {
-					'none' => 'allow',
-					'allow' => 'deny',
-					default => 'none',
-				};
-	?>
-			<td id="cell-<?= $action->id ?>-<?= $role->id ?>"
-				class="matrix-cell <?= h($type) ?>"
-				hx-post="<?= $this->Url->build(['action' => 'toggle']) ?>"
-				hx-vals='<?= json_encode(['action_id' => $action->id, 'role_id' => $role->id, 'type' => $nextType]) ?>'
-				hx-swap="outerHTML">
-				<?= $symbol ?>
-			</td>
+				<?= $this->element('TinyAuthBackend.acl_cell', ['cell' => $permissions[$action->id][$role->id]]) ?>
 			<?php } ?>
 		</tr>
 		<?php } ?>

--- a/tests/TestCase/Controller/Admin/AclControllerTest.php
+++ b/tests/TestCase/Controller/Admin/AclControllerTest.php
@@ -34,7 +34,7 @@ class AclControllerTest extends TestCase {
 			'id' => 1,
 			'name' => 'User',
 			'alias' => 'user',
-			'parent_id' => null,
+			'parent_id' => 2,
 			'sort_order' => 1,
 		]);
 		$this->insertRow('tinyauth_roles', [
@@ -68,6 +68,42 @@ class AclControllerTest extends TestCase {
 		$this->assertResponseContains('index');
 	}
 
+	public function testIndexShowsInheritedPermissionState(): void {
+		$this->insertRow('tinyauth_acl_permissions', [
+			'id' => 1,
+			'action_id' => 1,
+			'role_id' => 1,
+			'type' => 'allow',
+		]);
+
+		$this->get(['prefix' => 'Admin', 'plugin' => 'TinyAuthBackend', 'controller' => 'Acl', '?' => ['controller_id' => 1]]);
+
+		$this->assertResponseCode(200);
+		$this->assertResponseContains('data-state="inherited"');
+		$this->assertResponseContains('title="Inherited permission"');
+	}
+
+	public function testIndexPrefersExplicitDenyOverInheritedPermissionState(): void {
+		$this->insertRow('tinyauth_acl_permissions', [
+			'id' => 1,
+			'action_id' => 1,
+			'role_id' => 1,
+			'type' => 'allow',
+		]);
+		$this->insertRow('tinyauth_acl_permissions', [
+			'id' => 2,
+			'action_id' => 1,
+			'role_id' => 2,
+			'type' => 'deny',
+		]);
+
+		$this->get(['prefix' => 'Admin', 'plugin' => 'TinyAuthBackend', 'controller' => 'Acl', '?' => ['controller_id' => 1]]);
+
+		$this->assertResponseCode(200);
+		$this->assertResponseContains('data-state="deny"');
+		$this->assertResponseContains('title="Denied"');
+	}
+
 	public function testToggleCreatesPermission(): void {
 		$this->post(['prefix' => 'Admin', 'plugin' => 'TinyAuthBackend', 'controller' => 'Acl', 'action' => 'toggle'], [
 			'action_id' => 1,
@@ -95,6 +131,32 @@ class AclControllerTest extends TestCase {
 
 		$this->assertResponseCode(200);
 		$this->assertSame(1, $this->countRows('tinyauth_acl_permissions', ['action_id' => 1, 'role_id' => 1, 'type' => 'deny']));
+	}
+
+	public function testToggleRemovingExplicitDenyFallsBackToInheritedState(): void {
+		$this->insertRow('tinyauth_acl_permissions', [
+			'id' => 1,
+			'action_id' => 1,
+			'role_id' => 1,
+			'type' => 'allow',
+		]);
+		$this->insertRow('tinyauth_acl_permissions', [
+			'id' => 2,
+			'action_id' => 1,
+			'role_id' => 2,
+			'type' => 'deny',
+		]);
+
+		$this->post(['prefix' => 'Admin', 'plugin' => 'TinyAuthBackend', 'controller' => 'Acl', 'action' => 'toggle'], [
+			'action_id' => 1,
+			'role_id' => 2,
+			'type' => 'none',
+		]);
+
+		$this->assertResponseCode(200);
+		$this->assertResponseContains('data-state="inherited"');
+		$this->assertResponseContains('title="Inherited permission"');
+		$this->assertSame(0, $this->countRows('tinyauth_acl_permissions', ['action_id' => 1, 'role_id' => 2]));
 	}
 
 	public function testSearchReturnsMatchingInternalRecords(): void {


### PR DESCRIPTION
## Summary
- show inherited ACL permissions as a distinct matrix state in the admin UI
- keep direct and effective permission evaluation separate so the matrix matches runtime hierarchy behavior
- reuse the same cell rendering for the full matrix and HTMX toggle updates

## Details
The ACL page previously rendered only direct `tinyauth_acl_permissions` rows, so inherited allows were shown as `no permission` even though runtime ACL resolution granted access through hierarchy.

This change adds a computed inherited state for the matrix:
- `allow`: explicit allow
- `inherited`: effective allow inherited from a lower role
- `deny`: explicit deny
- `none`: no direct or inherited permission

It also updates the HTMX toggle response so a cell can fall back to `inherited` after removing an explicit override.

## Tests
- added controller coverage for inherited display
- added coverage for explicit deny overriding inherited allow
- added coverage for reverting from explicit deny back to inherited

## Verification
- `vendor/bin/phpunit`
- `vendor/bin/phpcs --colors --parallel=16`
- `composer stan-setup && vendor/bin/phpstan analyse --no-progress`
