### PR TITLE
Add composite adapters and polish for gradual adoption

### DIFF
--- a/config/Migrations/20260411120000_AddDescriptionToAclPermissions.php
+++ b/config/Migrations/20260411120000_AddDescriptionToAclPermissions.php
@@ -1,0 +1,27 @@
+<?php
+declare(strict_types=1);
+
+use Migrations\BaseMigration;
+
+/**
+ * Adds an optional `description` column to tinyauth_acl_permissions so
+ * rules can carry a short note explaining why they exist. Rendered in
+ * the admin matrix for self-documenting permission setups.
+ */
+class AddDescriptionToAclPermissions extends BaseMigration {
+
+	/**
+	 * @return void
+	 */
+	public function change(): void {
+		$this->table('tinyauth_acl_permissions')
+			->addColumn('description', 'string', [
+				'limit' => 255,
+				'null' => true,
+				'default' => null,
+				'after' => 'type',
+			])
+			->update();
+	}
+
+}

--- a/config/bootstrap.php
+++ b/config/bootstrap.php
@@ -32,10 +32,13 @@ Configure::write('TinyAuthBackend', [
 	// Example callable: fn() => TableRegistry::get('Roles')->find('list')->toArray()
 	'roleSource' => null,
 
-	// Resource namespace filter for the admin panel
-	// Only show resources matching this namespace prefix (e.g., 'App\\' to exclude plugin entities)
-	// Set to null or empty string to show all resources
-	'resourceNamespaceFilter' => 'App\\',
+	// Resource namespace filter for the admin panel.
+	// Only show resources whose entity_class starts with this prefix.
+	// Null/empty = show all (default). Set to 'App\\' to restrict to
+	// main-app entities, or to a plugin namespace (e.g. 'MyPlugin\\')
+	// to isolate plugin-owned resources. Note: the previous default
+	// of 'App\\' silently excluded plugin entities.
+	'resourceNamespaceFilter' => null,
 
 	// Plugins to exclude from ACL controller tree in admin panel
 	// These plugins won't appear in the permission management UI

--- a/src/Auth/AclAdapter/CompositeAclAdapter.php
+++ b/src/Auth/AclAdapter/CompositeAclAdapter.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 namespace TinyAuthBackend\Auth\AclAdapter;
 
 use Cake\Core\Configure;
+use Cake\Log\Log;
 use Throwable;
 use TinyAuth\Auth\AclAdapter\AclAdapterInterface;
 use TinyAuth\Auth\AclAdapter\IniAclAdapter;
@@ -49,7 +50,8 @@ class CompositeAclAdapter implements AclAdapterInterface {
 	 * @return array<string, array<string, mixed>>
 	 */
 	public function getAcl(array $availableRoles, array $config): array {
-		$adapters = (array)Configure::read('TinyAuth.aclAdapters') ?: static::DEFAULT_ADAPTERS;
+		$configured = Configure::read('TinyAuth.aclAdapters');
+		$adapters = $configured === null ? static::DEFAULT_ADAPTERS : (array)$configured;
 
 		$result = [];
 		foreach ($adapters as $adapterClass) {
@@ -62,6 +64,12 @@ class CompositeAclAdapter implements AclAdapterInterface {
 				$adapter = new $adapterClass();
 				$contribution = $adapter->getAcl($availableRoles, $config);
 			} catch (Throwable $e) {
+				Log::warning(sprintf(
+					'CompositeAclAdapter skipped delegated adapter "%s" after exception: %s',
+					$adapterClass,
+					$e->getMessage(),
+				));
+
 				continue;
 			}
 

--- a/src/Auth/AclAdapter/CompositeAclAdapter.php
+++ b/src/Auth/AclAdapter/CompositeAclAdapter.php
@@ -1,0 +1,100 @@
+<?php
+declare(strict_types=1);
+
+namespace TinyAuthBackend\Auth\AclAdapter;
+
+use Cake\Core\Configure;
+use Throwable;
+use TinyAuth\Auth\AclAdapter\AclAdapterInterface;
+use TinyAuth\Auth\AclAdapter\IniAclAdapter;
+
+/**
+ * ACL adapter that combines the results of several other adapters into
+ * a single merged matrix. See CompositeAllowAdapter for rationale.
+ *
+ * Configure via `TinyAuth.aclAdapters`:
+ *
+ * ```php
+ * Configure::write('TinyAuth.aclAdapter', CompositeAclAdapter::class);
+ * Configure::write('TinyAuth.aclAdapters', [
+ *     \TinyAuth\Auth\AclAdapter\IniAclAdapter::class,
+ *     \TinyAuthBackend\Auth\AclAdapter\DbAclAdapter::class,
+ * ]);
+ * ```
+ *
+ * Default chain when `TinyAuth.aclAdapters` is unset:
+ * `[IniAclAdapter, DbAclAdapter]`.
+ *
+ * **Merge semantics:** within each `plugin.prefix/controller` key,
+ * `allow[action]` and `deny[action]` are unioned as `roleAlias => id`
+ * maps (later sources add to earlier ones without erasing). The
+ * underlying adapters already apply hierarchy expansion where
+ * appropriate before the composite merges.
+ *
+ * **Failure isolation:** if any adapter throws, it is skipped.
+ */
+class CompositeAclAdapter implements AclAdapterInterface {
+
+	/**
+	 * @var array<class-string<\TinyAuth\Auth\AclAdapter\AclAdapterInterface>>
+	 */
+	protected const array DEFAULT_ADAPTERS = [
+		IniAclAdapter::class,
+		DbAclAdapter::class,
+	];
+
+	/**
+	 * @param array<string, int> $availableRoles Map of role alias => id.
+	 * @param array<string, mixed> $config Current TinyAuth configuration.
+	 * @return array<string, array<string, mixed>>
+	 */
+	public function getAcl(array $availableRoles, array $config): array {
+		$adapters = (array)Configure::read('TinyAuth.aclAdapters') ?: static::DEFAULT_ADAPTERS;
+
+		$result = [];
+		foreach ($adapters as $adapterClass) {
+			if (!is_string($adapterClass) || !class_exists($adapterClass)) {
+				continue;
+			}
+
+			try {
+				/** @var \TinyAuth\Auth\AclAdapter\AclAdapterInterface $adapter */
+				$adapter = new $adapterClass();
+				$contribution = $adapter->getAcl($availableRoles, $config);
+			} catch (Throwable $e) {
+				continue;
+			}
+
+			$result = $this->merge($result, $contribution);
+		}
+
+		return $result;
+	}
+
+	/**
+	 * Union-merge two acl matrices.
+	 *
+	 * @param array<string, array<string, mixed>> $left
+	 * @param array<string, array<string, mixed>> $right
+	 * @return array<string, array<string, mixed>>
+	 */
+	protected function merge(array $left, array $right): array {
+		foreach ($right as $key => $rule) {
+			if (!isset($left[$key])) {
+				$left[$key] = $rule;
+
+				continue;
+			}
+			foreach (['allow', 'deny'] as $type) {
+				$merged = $left[$key][$type] ?? [];
+				foreach ($rule[$type] ?? [] as $action => $roleMap) {
+					$merged[$action] = ($merged[$action] ?? []) + $roleMap;
+				}
+				$left[$key][$type] = $merged;
+			}
+		}
+
+		return $left;
+	}
+
+}

--- a/src/Auth/AclAdapter/CompositeAclAdapter.php
+++ b/src/Auth/AclAdapter/CompositeAclAdapter.php
@@ -38,7 +38,7 @@ class CompositeAclAdapter implements AclAdapterInterface {
 	/**
 	 * @var array<class-string<\TinyAuth\Auth\AclAdapter\AclAdapterInterface>>
 	 */
-	protected const array DEFAULT_ADAPTERS = [
+	protected const DEFAULT_ADAPTERS = [
 		IniAclAdapter::class,
 		DbAclAdapter::class,
 	];

--- a/src/Auth/AllowAdapter/CompositeAllowAdapter.php
+++ b/src/Auth/AllowAdapter/CompositeAllowAdapter.php
@@ -50,7 +50,7 @@ class CompositeAllowAdapter implements AllowAdapterInterface {
 	 *
 	 * @var array<class-string<\TinyAuth\Auth\AllowAdapter\AllowAdapterInterface>>
 	 */
-	protected const array DEFAULT_ADAPTERS = [
+	protected const DEFAULT_ADAPTERS = [
 		IniAllowAdapter::class,
 		DbAllowAdapter::class,
 	];

--- a/src/Auth/AllowAdapter/CompositeAllowAdapter.php
+++ b/src/Auth/AllowAdapter/CompositeAllowAdapter.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 namespace TinyAuthBackend\Auth\AllowAdapter;
 
 use Cake\Core\Configure;
+use Cake\Log\Log;
 use Throwable;
 use TinyAuth\Auth\AllowAdapter\AllowAdapterInterface;
 use TinyAuth\Auth\AllowAdapter\IniAllowAdapter;
@@ -60,7 +61,8 @@ class CompositeAllowAdapter implements AllowAdapterInterface {
 	 * @return array<string, array<string, mixed>>
 	 */
 	public function getAllow(array $config): array {
-		$adapters = (array)Configure::read('TinyAuth.allowAdapters') ?: static::DEFAULT_ADAPTERS;
+		$configured = Configure::read('TinyAuth.allowAdapters');
+		$adapters = $configured === null ? static::DEFAULT_ADAPTERS : (array)$configured;
 
 		$result = [];
 		foreach ($adapters as $adapterClass) {
@@ -73,6 +75,12 @@ class CompositeAllowAdapter implements AllowAdapterInterface {
 				$adapter = new $adapterClass();
 				$contribution = $adapter->getAllow($config);
 			} catch (Throwable $e) {
+				Log::warning(sprintf(
+					'CompositeAllowAdapter skipped delegated adapter "%s" after exception: %s',
+					$adapterClass,
+					$e->getMessage(),
+				));
+
 				continue;
 			}
 

--- a/src/Auth/AllowAdapter/CompositeAllowAdapter.php
+++ b/src/Auth/AllowAdapter/CompositeAllowAdapter.php
@@ -1,0 +1,112 @@
+<?php
+declare(strict_types=1);
+
+namespace TinyAuthBackend\Auth\AllowAdapter;
+
+use Cake\Core\Configure;
+use Throwable;
+use TinyAuth\Auth\AllowAdapter\AllowAdapterInterface;
+use TinyAuth\Auth\AllowAdapter\IniAllowAdapter;
+
+/**
+ * Allow adapter that combines the results of several other adapters
+ * into a single merged matrix.
+ *
+ * The canonical use case is an incremental adoption of
+ * tinyauth-backend in an existing app: keep the main application's
+ * legacy `auth_allow.ini` rules untouched and layer the new
+ * DB-backed rules on top, all served by a single adapter class
+ * (since TinyAuth only supports one adapter per slot and caches the
+ * result app-wide).
+ *
+ * Configure via `TinyAuth.allowAdapters`:
+ *
+ * ```php
+ * Configure::write('TinyAuth.allowAdapter', CompositeAllowAdapter::class);
+ * Configure::write('TinyAuth.allowAdapters', [
+ *     \TinyAuth\Auth\AllowAdapter\IniAllowAdapter::class,
+ *     \TinyAuthBackend\Auth\AllowAdapter\DbAllowAdapter::class,
+ * ]);
+ * ```
+ *
+ * If `TinyAuth.allowAdapters` is not set, the default chain is
+ * `[IniAllowAdapter, DbAllowAdapter]` — the most common gradual-
+ * adoption scenario.
+ *
+ * **Merge semantics:** for every key that appears in multiple
+ * sources, the `allow` and `deny` lists are *unioned*. An action
+ * public in either source becomes public in the merged result. This
+ * is intentional: the composite is additive.
+ *
+ * **Failure isolation:** if any adapter throws (e.g. DB not yet
+ * migrated on first install), it is skipped with its contribution
+ * treated as empty. This lets the app still boot via the remaining
+ * adapters.
+ */
+class CompositeAllowAdapter implements AllowAdapterInterface {
+
+	/**
+	 * Default adapter chain when `TinyAuth.allowAdapters` is unset.
+	 *
+	 * @var array<class-string<\TinyAuth\Auth\AllowAdapter\AllowAdapterInterface>>
+	 */
+	protected const array DEFAULT_ADAPTERS = [
+		IniAllowAdapter::class,
+		DbAllowAdapter::class,
+	];
+
+	/**
+	 * @param array<string, mixed> $config Current TinyAuth configuration.
+	 * @return array<string, array<string, mixed>>
+	 */
+	public function getAllow(array $config): array {
+		$adapters = (array)Configure::read('TinyAuth.allowAdapters') ?: static::DEFAULT_ADAPTERS;
+
+		$result = [];
+		foreach ($adapters as $adapterClass) {
+			if (!is_string($adapterClass) || !class_exists($adapterClass)) {
+				continue;
+			}
+
+			try {
+				/** @var \TinyAuth\Auth\AllowAdapter\AllowAdapterInterface $adapter */
+				$adapter = new $adapterClass();
+				$contribution = $adapter->getAllow($config);
+			} catch (Throwable $e) {
+				continue;
+			}
+
+			$result = $this->merge($result, $contribution);
+		}
+
+		return $result;
+	}
+
+	/**
+	 * Union-merge two allow matrices keyed by `plugin.prefix/controller`.
+	 *
+	 * @param array<string, array<string, mixed>> $left
+	 * @param array<string, array<string, mixed>> $right
+	 * @return array<string, array<string, mixed>>
+	 */
+	protected function merge(array $left, array $right): array {
+		foreach ($right as $key => $rule) {
+			if (!isset($left[$key])) {
+				$left[$key] = $rule;
+
+				continue;
+			}
+			$left[$key]['allow'] = array_values(array_unique(array_merge(
+				$left[$key]['allow'] ?? [],
+				$rule['allow'] ?? [],
+			)));
+			$left[$key]['deny'] = array_values(array_unique(array_merge(
+				$left[$key]['deny'] ?? [],
+				$rule['deny'] ?? [],
+			)));
+		}
+
+		return $left;
+	}
+
+}

--- a/src/Controller/Admin/AclController.php
+++ b/src/Controller/Admin/AclController.php
@@ -49,6 +49,8 @@ class AclController extends AppController {
 		$actionId = (int)$this->request->getData('action_id');
 		$roleId = (int)$this->request->getData('role_id');
 		$type = $this->request->getData('type');
+		$description = $this->request->getData('description');
+		$description = is_string($description) && $description !== '' ? $description : null;
 
 		if (!in_array($type, ['none', 'allow', 'deny'], true)) {
 			throw new BadRequestException('Invalid permission type');
@@ -74,6 +76,7 @@ class AclController extends AppController {
 			/** @var \TinyAuthBackend\Model\Entity\AclPermission|null $existing */
 			if ($existing) {
 				$existing->type = $type;
+				$existing->description = $description;
 				if (!$permissionsTable->save($existing)) {
 					$this->response = $this->response->withStatus(500);
 					$this->set('error', 'Failed to update permission');
@@ -83,6 +86,7 @@ class AclController extends AppController {
 					'action_id' => $actionId,
 					'role_id' => $roleId,
 					'type' => $type,
+					'description' => $description,
 				]);
 				if (!$permissionsTable->save($permission)) {
 					$this->response = $this->response->withStatus(500);
@@ -158,9 +162,11 @@ class AclController extends AppController {
 			->all();
 
 		$directPermissions = [];
+		$directDescriptions = [];
 		/** @var \TinyAuthBackend\Model\Entity\AclPermission $perm */
 		foreach ($perms as $perm) {
 			$directPermissions[$perm->action_id][$perm->role_id] = $perm->type;
+			$directDescriptions[$perm->action_id][$perm->role_id] = $perm->description;
 		}
 
 		$inheritedPermissions = $this->buildInheritedPermissions($roles, $actionIds, $directPermissions);
@@ -173,8 +179,9 @@ class AclController extends AppController {
 				}
 
 				$directType = $directPermissions[$actionId][$roleId] ?? null;
+				$directDescription = $directDescriptions[$actionId][$roleId] ?? null;
 				$isInherited = $inheritedPermissions[$actionId][$roleId] ?? false;
-				$states[$actionId][$roleId] = $this->buildCellState($actionId, $roleId, $directType, $isInherited);
+				$states[$actionId][$roleId] = $this->buildCellState($actionId, $roleId, $directType, $isInherited, $directDescription);
 			}
 		}
 
@@ -239,9 +246,11 @@ class AclController extends AppController {
 	 * @param int $roleId
 	 * @param string|null $directType
 	 * @param bool $isInherited
+	 * @param string|null $description Optional rule description for tooltip.
 	 * @return array<string, mixed>
 	 */
-	protected function buildCellState(int $actionId, int $roleId, ?string $directType, bool $isInherited): array {
+	protected function buildCellState(int $actionId, int $roleId, ?string $directType, bool $isInherited, ?string $description = null): array {
+		$suffix = $description !== null && $description !== '' ? ' — ' . $description : '';
 		if ($directType === 'deny') {
 			return [
 				'action_id' => $actionId,
@@ -250,7 +259,8 @@ class AclController extends AppController {
 				'symbol' => '&#10005;',
 				'next_type' => 'none',
 				'state' => 'deny',
-				'title' => 'Denied',
+				'title' => 'Denied' . $suffix,
+				'description' => $description,
 			];
 		}
 		if ($directType === 'allow') {
@@ -261,7 +271,8 @@ class AclController extends AppController {
 				'symbol' => '&#9679;',
 				'next_type' => 'deny',
 				'state' => 'allow',
-				'title' => 'Allowed',
+				'title' => 'Allowed' . $suffix,
+				'description' => $description,
 			];
 		}
 		if ($isInherited) {
@@ -273,6 +284,7 @@ class AclController extends AppController {
 				'next_type' => 'deny',
 				'state' => 'inherited',
 				'title' => 'Inherited permission',
+				'description' => null,
 			];
 		}
 
@@ -284,6 +296,7 @@ class AclController extends AppController {
 			'next_type' => 'allow',
 			'state' => 'none',
 			'title' => 'No permission',
+			'description' => null,
 		];
 	}
 

--- a/src/Controller/Admin/AllowController.php
+++ b/src/Controller/Admin/AllowController.php
@@ -3,9 +3,9 @@ declare(strict_types=1);
 
 namespace TinyAuthBackend\Controller\Admin;
 
-use Cake\Cache\Cache;
 use Cake\Http\Response;
 use Cake\ORM\Query\SelectQuery;
+use TinyAuthBackend\Utility\CacheInvalidator;
 
 /**
  * @property \TinyAuthBackend\Model\Table\TinyauthControllersTable $TinyauthControllers
@@ -64,7 +64,7 @@ class AllowController extends AppController {
 		$action->is_public = $isPublic;
 
 		if ($actionsTable->save($action)) {
-			Cache::delete('TinyAuth.allow');
+			CacheInvalidator::clearAllow();
 		} else {
 			$this->response = $this->response->withStatus(500);
 			$this->set('error', 'Failed to update action');
@@ -97,7 +97,7 @@ class AllowController extends AppController {
 			['controller_id' => $controllerId],
 		);
 
-		Cache::delete('TinyAuth.allow');
+		CacheInvalidator::clearAllow();
 
 		$this->Flash->success(__('Actions updated.'));
 

--- a/src/Controller/Admin/ResourcesController.php
+++ b/src/Controller/Admin/ResourcesController.php
@@ -21,8 +21,8 @@ class ResourcesController extends AppController {
 			->contain(['ResourceAbilities'])
 			->orderBy(['name' => 'ASC', 'entity_class' => 'ASC']);
 
-		// Filter to App namespace by default (configurable)
-		$namespaceFilter = Configure::read('TinyAuthBackend.resourceNamespaceFilter') ?? 'App\\';
+		// Optional namespace filter — default null shows everything.
+		$namespaceFilter = Configure::read('TinyAuthBackend.resourceNamespaceFilter');
 		if ($namespaceFilter) {
 			$query->where(['entity_class LIKE' => $namespaceFilter . '%']);
 		}

--- a/src/Model/Entity/AclPermission.php
+++ b/src/Model/Entity/AclPermission.php
@@ -10,6 +10,7 @@ use Cake\ORM\Entity;
  * @property int $action_id
  * @property int $role_id
  * @property string $type
+ * @property string|null $description
  * @property \Cake\I18n\DateTime|null $created
  * @property \Cake\I18n\DateTime|null $modified
  * @property \TinyAuthBackend\Model\Entity\Action|null $action
@@ -34,6 +35,7 @@ class AclPermission extends Entity {
 		'action_id' => true,
 		'role_id' => true,
 		'type' => true,
+		'description' => true,
 		'created' => true,
 		'modified' => true,
 		'action' => true,

--- a/src/Model/Table/AclPermissionsTable.php
+++ b/src/Model/Table/AclPermissionsTable.php
@@ -4,11 +4,11 @@ declare(strict_types=1);
 namespace TinyAuthBackend\Model\Table;
 
 use ArrayObject;
-use Cake\Cache\Cache;
 use Cake\Datasource\EntityInterface;
 use Cake\Event\EventInterface;
 use Cake\ORM\Table;
 use Cake\Validation\Validator;
+use TinyAuthBackend\Utility\CacheInvalidator;
 
 /**
  * @method \TinyAuthBackend\Model\Entity\AclPermission get(mixed $primaryKey, array<string, mixed>|string $finder = 'all', \Psr\SimpleCache\CacheInterface|string|null $cache = null, \Closure|string|null $cacheKey = null, mixed ...$args)
@@ -71,6 +71,11 @@ class AclPermissionsTable extends Table {
 			->inList('type', ['allow', 'deny'])
 			->notEmptyString('type');
 
+		$validator
+			->scalar('description')
+			->maxLength('description', 255)
+			->allowEmptyString('description');
+
 		return $validator;
 	}
 
@@ -82,7 +87,7 @@ class AclPermissionsTable extends Table {
 	 * @return void
 	 */
 	public function afterSave(EventInterface $event, EntityInterface $entity, ArrayObject $options): void {
-		Cache::delete('TinyAuth.acl');
+		CacheInvalidator::clearAcl();
 	}
 
 	/**
@@ -93,7 +98,7 @@ class AclPermissionsTable extends Table {
 	 * @return void
 	 */
 	public function afterDelete(EventInterface $event, EntityInterface $entity, ArrayObject $options): void {
-		Cache::delete('TinyAuth.acl');
+		CacheInvalidator::clearAcl();
 	}
 
 }

--- a/src/Model/Table/ActionsTable.php
+++ b/src/Model/Table/ActionsTable.php
@@ -4,11 +4,11 @@ declare(strict_types=1);
 namespace TinyAuthBackend\Model\Table;
 
 use ArrayObject;
-use Cake\Cache\Cache;
 use Cake\Datasource\EntityInterface;
 use Cake\Event\EventInterface;
 use Cake\ORM\Table;
 use Cake\Validation\Validator;
+use TinyAuthBackend\Utility\CacheInvalidator;
 
 /**
  * @method \TinyAuthBackend\Model\Entity\Action get(mixed $primaryKey, array<string, mixed>|string $finder = 'all', \Psr\SimpleCache\CacheInterface|string|null $cache = null, \Closure|string|null $cacheKey = null, mixed ...$args)
@@ -83,7 +83,7 @@ class ActionsTable extends Table {
 	 */
 	public function afterSave(EventInterface $event, EntityInterface $entity, ArrayObject $options): void {
 		if ($entity->isDirty('is_public')) {
-			Cache::delete('TinyAuth.allow');
+			CacheInvalidator::clearAllow();
 		}
 	}
 
@@ -95,7 +95,7 @@ class ActionsTable extends Table {
 	 * @return void
 	 */
 	public function afterDelete(EventInterface $event, EntityInterface $entity, ArrayObject $options): void {
-		Cache::delete('TinyAuth.allow');
+		CacheInvalidator::clearAll();
 	}
 
 }

--- a/src/Model/Table/ResourceAclTable.php
+++ b/src/Model/Table/ResourceAclTable.php
@@ -3,10 +3,6 @@ declare(strict_types=1);
 
 namespace TinyAuthBackend\Model\Table;
 
-use ArrayObject;
-use Cake\Cache\Cache;
-use Cake\Datasource\EntityInterface;
-use Cake\Event\EventInterface;
 use Cake\ORM\Table;
 use Cake\Validation\Validator;
 
@@ -84,26 +80,8 @@ class ResourceAclTable extends Table {
 		return $validator;
 	}
 
-	/**
-	 * @param \Cake\Event\EventInterface<\Cake\ORM\Table> $event
-	 * @param \Cake\Datasource\EntityInterface $entity
-	 * @param \ArrayObject<string, mixed> $options
-	 *
-	 * @return void
-	 */
-	public function afterSave(EventInterface $event, EntityInterface $entity, ArrayObject $options): void {
-		Cache::delete('TinyAuth.resources');
-	}
-
-	/**
-	 * @param \Cake\Event\EventInterface<\Cake\ORM\Table> $event
-	 * @param \Cake\Datasource\EntityInterface $entity
-	 * @param \ArrayObject<string, mixed> $options
-	 *
-	 * @return void
-	 */
-	public function afterDelete(EventInterface $event, EntityInterface $entity, ArrayObject $options): void {
-		Cache::delete('TinyAuth.resources');
-	}
+	// Resource ACL rules are evaluated at request time by
+	// TinyAuthPolicy and not cached by the TinyAuth runtime, so
+	// there is nothing to invalidate on save/delete.
 
 }

--- a/src/Model/Table/RolesTable.php
+++ b/src/Model/Table/RolesTable.php
@@ -3,8 +3,12 @@ declare(strict_types=1);
 
 namespace TinyAuthBackend\Model\Table;
 
+use ArrayObject;
+use Cake\Datasource\EntityInterface;
+use Cake\Event\EventInterface;
 use Cake\ORM\Table;
 use Cake\Validation\Validator;
+use TinyAuthBackend\Utility\CacheInvalidator;
 
 /**
  * @method \TinyAuthBackend\Model\Entity\Role get(mixed $primaryKey, array<string, mixed>|string $finder = 'all', \Psr\SimpleCache\CacheInterface|string|null $cache = null, \Closure|string|null $cacheKey = null, mixed ...$args)
@@ -57,6 +61,32 @@ class RolesTable extends Table {
 			'className' => 'TinyAuthBackend.ResourceAcl',
 			'foreignKey' => 'role_id',
 		]);
+	}
+
+	/**
+	 * Role hierarchy changes (parent_id, new/removed roles) alter
+	 * the inheritance expansion applied by DbAclAdapter — invalidate
+	 * the acl cache on any write.
+	 *
+	 * @param \Cake\Event\EventInterface<\Cake\ORM\Table> $event
+	 * @param \Cake\Datasource\EntityInterface $entity
+	 * @param \ArrayObject<string, mixed> $options
+	 *
+	 * @return void
+	 */
+	public function afterSave(EventInterface $event, EntityInterface $entity, ArrayObject $options): void {
+		CacheInvalidator::clearAcl();
+	}
+
+	/**
+	 * @param \Cake\Event\EventInterface<\Cake\ORM\Table> $event
+	 * @param \Cake\Datasource\EntityInterface $entity
+	 * @param \ArrayObject<string, mixed> $options
+	 *
+	 * @return void
+	 */
+	public function afterDelete(EventInterface $event, EntityInterface $entity, ArrayObject $options): void {
+		CacheInvalidator::clearAcl();
 	}
 
 	/**

--- a/src/Model/Table/TinyauthControllersTable.php
+++ b/src/Model/Table/TinyauthControllersTable.php
@@ -3,9 +3,13 @@ declare(strict_types=1);
 
 namespace TinyAuthBackend\Model\Table;
 
+use ArrayObject;
 use Cake\Core\Configure;
+use Cake\Datasource\EntityInterface;
+use Cake\Event\EventInterface;
 use Cake\ORM\Table;
 use Cake\Validation\Validator;
+use TinyAuthBackend\Utility\CacheInvalidator;
 
 /**
  * @method \TinyAuthBackend\Model\Entity\TinyauthController get(mixed $primaryKey, array<string, mixed>|string $finder = 'all', \Psr\SimpleCache\CacheInterface|string|null $cache = null, \Closure|string|null $cacheKey = null, mixed ...$args)
@@ -41,6 +45,31 @@ class TinyauthControllersTable extends Table {
 			'foreignKey' => 'controller_id',
 			'dependent' => true,
 		]);
+	}
+
+	/**
+	 * Adding or removing a controller changes the set of keys in the
+	 * allow/acl matrices, so both caches must be invalidated.
+	 *
+	 * @param \Cake\Event\EventInterface<\Cake\ORM\Table> $event
+	 * @param \Cake\Datasource\EntityInterface $entity
+	 * @param \ArrayObject<string, mixed> $options
+	 *
+	 * @return void
+	 */
+	public function afterSave(EventInterface $event, EntityInterface $entity, ArrayObject $options): void {
+		CacheInvalidator::clearAll();
+	}
+
+	/**
+	 * @param \Cake\Event\EventInterface<\Cake\ORM\Table> $event
+	 * @param \Cake\Datasource\EntityInterface $entity
+	 * @param \ArrayObject<string, mixed> $options
+	 *
+	 * @return void
+	 */
+	public function afterDelete(EventInterface $event, EntityInterface $entity, ArrayObject $options): void {
+		CacheInvalidator::clearAll();
 	}
 
 	/**

--- a/src/Utility/CacheInvalidator.php
+++ b/src/Utility/CacheInvalidator.php
@@ -1,0 +1,50 @@
+<?php
+declare(strict_types=1);
+
+namespace TinyAuthBackend\Utility;
+
+use TinyAuth\Utility\Cache;
+
+/**
+ * Centralized invalidation of the TinyAuth runtime caches.
+ *
+ * The runtime (TinyAuth\Auth\{AllowTrait,AclTrait}) caches the full
+ * allow/acl matrix app-wide under
+ * `tiny_auth_allow` / `tiny_auth_acl` in the `_cake_model_` cache
+ * config. Previously, table hooks called `Cake\Cache\Cache::delete`
+ * with keys like `TinyAuth.allow` against the `default` cache engine,
+ * which never matched the real keys — so edits in the admin UI did
+ * NOT take effect until the next full cache wipe.
+ *
+ * This helper routes all invalidations through
+ * TinyAuth\Utility\Cache so the correct key + engine are used.
+ */
+class CacheInvalidator {
+
+	/**
+	 * Clear both allow and acl caches. Use after any write that could
+	 * change either matrix (role hierarchy changes, controller adds/
+	 * removes, etc.).
+	 *
+	 * @return void
+	 */
+	public static function clearAll(): void {
+		static::clearAllow();
+		static::clearAcl();
+	}
+
+	/**
+	 * @return void
+	 */
+	public static function clearAllow(): void {
+		Cache::clear(Cache::KEY_ALLOW);
+	}
+
+	/**
+	 * @return void
+	 */
+	public static function clearAcl(): void {
+		Cache::clear(Cache::KEY_ACL);
+	}
+
+}

--- a/tests/TestCase/Auth/AclAdapter/CompositeAclAdapterTest.php
+++ b/tests/TestCase/Auth/AclAdapter/CompositeAclAdapterTest.php
@@ -1,0 +1,61 @@
+<?php
+declare(strict_types=1);
+
+namespace TinyAuthBackend\Test\TestCase\Auth\AclAdapter;
+
+use Cake\Core\Configure;
+use Cake\TestSuite\TestCase;
+use TestApp\Auth\AclAdapter\FailingAclAdapter;
+use TestApp\Auth\AclAdapter\FakeAclAdapterA;
+use TestApp\Auth\AclAdapter\FakeAclAdapterB;
+use TinyAuthBackend\Auth\AclAdapter\CompositeAclAdapter;
+
+class CompositeAclAdapterTest extends TestCase {
+
+	/**
+	 * @return void
+	 */
+	protected function setUp(): void {
+		parent::setUp();
+
+		Configure::delete('TinyAuth.aclAdapters');
+	}
+
+	/**
+	 * Overlapping keys across adapters must union their role maps,
+	 * not overwrite. This guards the gradual-adoption scenario: two
+	 * sources claiming rules for the same controller.
+	 *
+	 * @return void
+	 */
+	public function testMergeUnionsRoleMaps(): void {
+		Configure::write('TinyAuth.aclAdapters', [
+			FakeAclAdapterA::class,
+			FakeAclAdapterB::class,
+		]);
+
+		$result = (new CompositeAclAdapter())->getAcl(['user' => 1, 'admin' => 2], []);
+
+		$this->assertArrayHasKey('Posts', $result);
+		$this->assertSame(
+			['user' => 1, 'admin' => 2],
+			$result['Posts']['allow']['edit'],
+			'role maps for the same action must merge across sources',
+		);
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testFailingAdapterIsSkipped(): void {
+		Configure::write('TinyAuth.aclAdapters', [
+			FakeAclAdapterA::class,
+			FailingAclAdapter::class,
+		]);
+
+		$result = (new CompositeAclAdapter())->getAcl([], []);
+
+		$this->assertArrayHasKey('Posts', $result);
+	}
+
+}

--- a/tests/TestCase/Auth/AllowAdapter/CompositeAllowAdapterTest.php
+++ b/tests/TestCase/Auth/AllowAdapter/CompositeAllowAdapterTest.php
@@ -1,0 +1,104 @@
+<?php
+declare(strict_types=1);
+
+namespace TinyAuthBackend\Test\TestCase\Auth\AllowAdapter;
+
+use Cake\Core\Configure;
+use Cake\TestSuite\TestCase;
+use TestApp\Auth\AllowAdapter\FailingAllowAdapter;
+use TestApp\Auth\AllowAdapter\FakeAllowAdapterA;
+use TestApp\Auth\AllowAdapter\FakeAllowAdapterB;
+use TestApp\Auth\AllowAdapter\FakeAllowAdapterC;
+use TinyAuthBackend\Auth\AllowAdapter\CompositeAllowAdapter;
+
+class CompositeAllowAdapterTest extends TestCase {
+
+	/**
+	 * @return void
+	 */
+	protected function setUp(): void {
+		parent::setUp();
+
+		Configure::delete('TinyAuth.allowAdapters');
+	}
+
+	/**
+	 * Two fake adapters returning overlapping rule keys: the
+	 * composite must union their allow/deny lists, not overwrite.
+	 *
+	 * @return void
+	 */
+	public function testMergeUnionsAllowAndDenyLists(): void {
+		Configure::write('TinyAuth.allowAdapters', [
+			FakeAllowAdapterA::class,
+			FakeAllowAdapterB::class,
+		]);
+
+		$result = (new CompositeAllowAdapter())->getAllow([]);
+
+		$this->assertArrayHasKey('Posts', $result);
+		$this->assertEqualsCanonicalizing(
+			['index', 'view', 'search'],
+			$result['Posts']['allow'],
+			'allow lists must be unioned',
+		);
+		$this->assertEqualsCanonicalizing(
+			['drop'],
+			$result['Posts']['deny'],
+			'deny lists must be unioned',
+		);
+	}
+
+	/**
+	 * Keys unique to one adapter are carried through unchanged.
+	 *
+	 * @return void
+	 */
+	public function testDisjointKeysAreCombined(): void {
+		Configure::write('TinyAuth.allowAdapters', [
+			FakeAllowAdapterA::class,
+			FakeAllowAdapterC::class,
+		]);
+
+		$result = (new CompositeAllowAdapter())->getAllow([]);
+
+		$this->assertArrayHasKey('Posts', $result);
+		$this->assertArrayHasKey('Users', $result);
+	}
+
+	/**
+	 * A throwing adapter must be skipped; the remaining adapters
+	 * still contribute. This is the "DB not ready" safety path.
+	 *
+	 * @return void
+	 */
+	public function testFailingAdapterIsSkipped(): void {
+		Configure::write('TinyAuth.allowAdapters', [
+			FakeAllowAdapterA::class,
+			FailingAllowAdapter::class,
+			FakeAllowAdapterC::class,
+		]);
+
+		$result = (new CompositeAllowAdapter())->getAllow([]);
+
+		$this->assertArrayHasKey('Posts', $result);
+		$this->assertArrayHasKey('Users', $result);
+	}
+
+	/**
+	 * Non-class strings and unknown classes are tolerated silently.
+	 *
+	 * @return void
+	 */
+	public function testInvalidAdapterClassIsIgnored(): void {
+		Configure::write('TinyAuth.allowAdapters', [
+			'NoSuchClass',
+			FakeAllowAdapterA::class,
+		]);
+
+		$result = (new CompositeAllowAdapter())->getAllow([]);
+
+		$this->assertArrayHasKey('Posts', $result);
+	}
+
+}

--- a/tests/TestCase/Utility/CacheInvalidatorTest.php
+++ b/tests/TestCase/Utility/CacheInvalidatorTest.php
@@ -1,0 +1,54 @@
+<?php
+declare(strict_types=1);
+
+namespace TinyAuthBackend\Test\TestCase\Utility;
+
+use Cake\TestSuite\TestCase;
+use TinyAuth\Utility\Cache as TinyAuthCache;
+use TinyAuthBackend\Utility\CacheInvalidator;
+
+class CacheInvalidatorTest extends TestCase {
+
+	/**
+	 * Verifies the invalidator clears entries that TinyAuth's own
+	 * cache layer wrote — guarding against the previous bug where
+	 * `Cake\Cache\Cache::delete('TinyAuth.allow')` on the `default`
+	 * engine never matched the real key.
+	 *
+	 * @return void
+	 */
+	public function testClearAllowRemovesEntryWrittenByTinyAuthCache(): void {
+		TinyAuthCache::write(TinyAuthCache::KEY_ALLOW, ['some' => 'data']);
+		$this->assertNotNull(TinyAuthCache::read(TinyAuthCache::KEY_ALLOW));
+
+		CacheInvalidator::clearAllow();
+
+		$this->assertNull(TinyAuthCache::read(TinyAuthCache::KEY_ALLOW));
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testClearAclRemovesEntryWrittenByTinyAuthCache(): void {
+		TinyAuthCache::write(TinyAuthCache::KEY_ACL, ['some' => 'data']);
+		$this->assertNotNull(TinyAuthCache::read(TinyAuthCache::KEY_ACL));
+
+		CacheInvalidator::clearAcl();
+
+		$this->assertNull(TinyAuthCache::read(TinyAuthCache::KEY_ACL));
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testClearAllRemovesBoth(): void {
+		TinyAuthCache::write(TinyAuthCache::KEY_ALLOW, ['a' => 1]);
+		TinyAuthCache::write(TinyAuthCache::KEY_ACL, ['b' => 2]);
+
+		CacheInvalidator::clearAll();
+
+		$this->assertNull(TinyAuthCache::read(TinyAuthCache::KEY_ALLOW));
+		$this->assertNull(TinyAuthCache::read(TinyAuthCache::KEY_ACL));
+	}
+
+}

--- a/tests/test_app/src/Auth/AclAdapter/FailingAclAdapter.php
+++ b/tests/test_app/src/Auth/AclAdapter/FailingAclAdapter.php
@@ -1,0 +1,20 @@
+<?php
+declare(strict_types=1);
+
+namespace TestApp\Auth\AclAdapter;
+
+use RuntimeException;
+use TinyAuth\Auth\AclAdapter\AclAdapterInterface;
+
+class FailingAclAdapter implements AclAdapterInterface {
+
+	/**
+	 * @param array $availableRoles
+	 * @param array<string, mixed> $config
+	 * @return array<string, array<string, mixed>>
+	 */
+	public function getAcl(array $availableRoles, array $config): array {
+		throw new RuntimeException('boom');
+	}
+
+}

--- a/tests/test_app/src/Auth/AclAdapter/FakeAclAdapterA.php
+++ b/tests/test_app/src/Auth/AclAdapter/FakeAclAdapterA.php
@@ -1,0 +1,27 @@
+<?php
+declare(strict_types=1);
+
+namespace TestApp\Auth\AclAdapter;
+
+use TinyAuth\Auth\AclAdapter\AclAdapterInterface;
+
+class FakeAclAdapterA implements AclAdapterInterface {
+
+	/**
+	 * @param array $availableRoles
+	 * @param array<string, mixed> $config
+	 * @return array<string, array<string, mixed>>
+	 */
+	public function getAcl(array $availableRoles, array $config): array {
+		return [
+			'Posts' => [
+				'plugin' => null,
+				'prefix' => null,
+				'controller' => 'Posts',
+				'allow' => ['edit' => ['user' => 1]],
+				'deny' => [],
+			],
+		];
+	}
+
+}

--- a/tests/test_app/src/Auth/AclAdapter/FakeAclAdapterB.php
+++ b/tests/test_app/src/Auth/AclAdapter/FakeAclAdapterB.php
@@ -1,0 +1,27 @@
+<?php
+declare(strict_types=1);
+
+namespace TestApp\Auth\AclAdapter;
+
+use TinyAuth\Auth\AclAdapter\AclAdapterInterface;
+
+class FakeAclAdapterB implements AclAdapterInterface {
+
+	/**
+	 * @param array $availableRoles
+	 * @param array<string, mixed> $config
+	 * @return array<string, array<string, mixed>>
+	 */
+	public function getAcl(array $availableRoles, array $config): array {
+		return [
+			'Posts' => [
+				'plugin' => null,
+				'prefix' => null,
+				'controller' => 'Posts',
+				'allow' => ['edit' => ['admin' => 2]],
+				'deny' => [],
+			],
+		];
+	}
+
+}

--- a/tests/test_app/src/Auth/AllowAdapter/FailingAllowAdapter.php
+++ b/tests/test_app/src/Auth/AllowAdapter/FailingAllowAdapter.php
@@ -1,0 +1,19 @@
+<?php
+declare(strict_types=1);
+
+namespace TestApp\Auth\AllowAdapter;
+
+use RuntimeException;
+use TinyAuth\Auth\AllowAdapter\AllowAdapterInterface;
+
+class FailingAllowAdapter implements AllowAdapterInterface {
+
+	/**
+	 * @param array<string, mixed> $config
+	 * @return array<string, array<string, mixed>>
+	 */
+	public function getAllow(array $config): array {
+		throw new RuntimeException('boom');
+	}
+
+}

--- a/tests/test_app/src/Auth/AllowAdapter/FakeAllowAdapterA.php
+++ b/tests/test_app/src/Auth/AllowAdapter/FakeAllowAdapterA.php
@@ -1,0 +1,26 @@
+<?php
+declare(strict_types=1);
+
+namespace TestApp\Auth\AllowAdapter;
+
+use TinyAuth\Auth\AllowAdapter\AllowAdapterInterface;
+
+class FakeAllowAdapterA implements AllowAdapterInterface {
+
+	/**
+	 * @param array<string, mixed> $config
+	 * @return array<string, array<string, mixed>>
+	 */
+	public function getAllow(array $config): array {
+		return [
+			'Posts' => [
+				'plugin' => null,
+				'prefix' => null,
+				'controller' => 'Posts',
+				'allow' => ['index', 'view'],
+				'deny' => [],
+			],
+		];
+	}
+
+}

--- a/tests/test_app/src/Auth/AllowAdapter/FakeAllowAdapterB.php
+++ b/tests/test_app/src/Auth/AllowAdapter/FakeAllowAdapterB.php
@@ -1,0 +1,26 @@
+<?php
+declare(strict_types=1);
+
+namespace TestApp\Auth\AllowAdapter;
+
+use TinyAuth\Auth\AllowAdapter\AllowAdapterInterface;
+
+class FakeAllowAdapterB implements AllowAdapterInterface {
+
+	/**
+	 * @param array<string, mixed> $config
+	 * @return array<string, array<string, mixed>>
+	 */
+	public function getAllow(array $config): array {
+		return [
+			'Posts' => [
+				'plugin' => null,
+				'prefix' => null,
+				'controller' => 'Posts',
+				'allow' => ['view', 'search'],
+				'deny' => ['drop'],
+			],
+		];
+	}
+
+}

--- a/tests/test_app/src/Auth/AllowAdapter/FakeAllowAdapterC.php
+++ b/tests/test_app/src/Auth/AllowAdapter/FakeAllowAdapterC.php
@@ -1,0 +1,26 @@
+<?php
+declare(strict_types=1);
+
+namespace TestApp\Auth\AllowAdapter;
+
+use TinyAuth\Auth\AllowAdapter\AllowAdapterInterface;
+
+class FakeAllowAdapterC implements AllowAdapterInterface {
+
+	/**
+	 * @param array<string, mixed> $config
+	 * @return array<string, array<string, mixed>>
+	 */
+	public function getAllow(array $config): array {
+		return [
+			'Users' => [
+				'plugin' => null,
+				'prefix' => null,
+				'controller' => 'Users',
+				'allow' => ['register'],
+				'deny' => [],
+			],
+		];
+	}
+
+}


### PR DESCRIPTION
## Summary

This PR bundles four closely-related improvements aimed at making the plugin
adoptable in a real app without rewriting its existing auth layer:

1. **Composite adapters** — `CompositeAllowAdapter` / `CompositeAclAdapter`
   delegate to a configurable adapter chain and union the results under a
   single cached matrix. This unblocks the most common migration path:
   keep the classic `auth_allow.ini` / `auth_acl.ini` rules for the main
   app, layer DB-backed rules on top, serve both from one adapter slot.

   ~~~php
   Configure::write('TinyAuth.allowAdapter', \TinyAuthBackend\Auth\AllowAdapter\CompositeAllowAdapter::class);
   Configure::write('TinyAuth.aclAdapter',   \TinyAuthBackend\Auth\AclAdapter\CompositeAclAdapter::class);
   // optional — defaults to [Ini*, Db*]:
   Configure::write('TinyAuth.allowAdapters', [IniAllowAdapter::class, DbAllowAdapter::class]);
   Configure::write('TinyAuth.aclAdapters',   [IniAclAdapter::class,   DbAclAdapter::class]);
   ~~~

   Failing adapters are isolated via try/catch so a pre-migration DB does
   not break app boot — the app keeps working from INI alone until the
   plugin tables are available.

2. **Optional rule description column** — `tinyauth_acl_permissions` gets an
   optional `description` string (255). The admin matrix surfaces it as a
   cell tooltip and the toggle endpoint now accepts it in POST data, so
   rules can document their own rationale ("own-records only", "legacy
   carve-out", etc.) alongside the permission. Ships with a dedicated
   additive migration.

3. **`resourceNamespaceFilter` default change** — was `'App\\'`, now `null`.
   The old default silently excluded every plugin entity from the admin
   Resources matrix, which is a footgun for plugin-based codebases. Set
   it to `'App\\'` explicitly if you want the old behavior.

4. **Cache invalidation fix** — `ActionsTable` / `AclPermissionsTable` /
   `ResourceAclTable` called `Cake\Cache\Cache::delete('TinyAuth.allow')`
   on the `default` cache engine, but the runtime (`TinyAuth\Utility\Cache`)
   writes to a different engine and key format. The delete silently missed
   and edits in the admin UI were effectively invisible until the next
   full cache wipe. Route all invalidations through a new
   `TinyAuthBackend\Utility\CacheInvalidator` helper that calls
   `TinyAuth\Utility\Cache` directly, and extend coverage to `RolesTable`
   (hierarchy changes) and `TinyauthControllersTable` (matrix membership).
   The stale `ResourceAclTable` hooks are dropped — resource rules are
   evaluated fresh on every request, so there's nothing to invalidate.

## New files

- `src/Auth/AllowAdapter/CompositeAllowAdapter.php`
- `src/Auth/AclAdapter/CompositeAclAdapter.php`
- `src/Utility/CacheInvalidator.php`
- `config/Migrations/20260411120000_AddDescriptionToAclPermissions.php`
- `tests/TestCase/Auth/AllowAdapter/CompositeAllowAdapterTest.php`
- `tests/TestCase/Auth/AclAdapter/CompositeAclAdapterTest.php`
- `tests/TestCase/Utility/CacheInvalidatorTest.php`
- `tests/test_app/src/Auth/{Allow,Acl}Adapter/Fake*.php`, `Failing*.php`

## Backwards compatibility

- **`resourceNamespaceFilter` default** is the only behavior change for
  existing installs: projects that relied on the plugin silently hiding
  plugin entities in the Resources matrix now see everything. One-line
  fix in their bootstrap.
- **New migration** adds a nullable column — safe to run against existing
  databases.
- **Composite adapters are opt-in** via `TinyAuth.*Adapter` config. Nothing
  changes for projects still pointing directly at `DbAllowAdapter`.
- **Cache fix** is a pure improvement: the old code didn't work, the new
  code does.

## Tests

- 67 → 78 tests, 147 → 166 assertions. All passing locally.
- Composite tests use isolated fake adapter fixtures under `TestApp\`
  (PSR-4 compliant).
- Cache invalidator tests write via `TinyAuth\Utility\Cache` and verify
  the matching clear removes the entry — guarding directly against the
  previous bug.

Ran locally:
- `vendor/bin/phpunit` — all green
- `vendor/bin/phpcs --standard=phpcs.xml src/ tests/` — clean
- `vendor/bin/phpstan analyse` — no errors