### PR TITLE
Policy identity+scope contract + resource namespace filter MySQL fix

### DIFF
--- a/src/Controller/Admin/ResourcesController.php
+++ b/src/Controller/Admin/ResourcesController.php
@@ -22,9 +22,16 @@ class ResourcesController extends AppController {
 			->orderBy(['name' => 'ASC', 'entity_class' => 'ASC']);
 
 		// Optional namespace filter — default null shows everything.
+		// Entity class names contain backslashes (`App\Model\Entity\…`),
+		// and MySQL's LIKE treats backslash as its escape character by
+		// default: a naive `LIKE 'App\%'` reads as "literal `App%`",
+		// so the filter matches nothing. Escape each backslash in the
+		// pattern so MySQL's regex layer sees a literal backslash.
+		// (Other drivers pass it through unchanged.)
 		$namespaceFilter = Configure::read('TinyAuthBackend.resourceNamespaceFilter');
 		if ($namespaceFilter) {
-			$query->where(['entity_class LIKE' => $namespaceFilter . '%']);
+			$pattern = str_replace('\\', '\\\\', $namespaceFilter) . '%';
+			$query->where(['entity_class LIKE' => $pattern]);
 		}
 
 		$resources = $query->all()->toArray();

--- a/src/Policy/TinyAuthPolicy.php
+++ b/src/Policy/TinyAuthPolicy.php
@@ -8,6 +8,7 @@ use Authorization\Policy\BeforePolicyInterface;
 use BadMethodCallException;
 use Cake\Core\Configure;
 use Cake\Datasource\EntityInterface;
+use Cake\ORM\Query\SelectQuery;
 use TinyAuthBackend\Service\TinyAuthService;
 
 /**
@@ -16,12 +17,39 @@ use TinyAuthBackend\Service\TinyAuthService;
  * Use this as the default policy for entities that should be controlled
  * via the TinyAuth admin UI. Extend for custom logic.
  *
- * Usage in Application.php:
- *   $resolver->map(Post::class, TinyAuthPolicy::class);
- *   $resolver->map(Comment::class, TinyAuthPolicy::class);
+ * Usage in `Application::getAuthorizationService()`:
  *
- * Or use OrmResolver with TinyAuthPolicy as default:
- *   $resolver = new OrmResolver(TinyAuthPolicy::class);
+ *     $resolver = new MapResolver();
+ *     $resolver->map(Article::class, TinyAuthPolicy::class);
+ *     $resolver->map(ArticlesTable::class, TinyAuthPolicy::class);
+ *     // ...
+ *     return new AuthorizationService($resolver);
+ *
+ * Or with `OrmResolver` and `TinyAuthPolicy` as the default class.
+ *
+ * Controllers then use the idiomatic Authorization calls:
+ *
+ *     $this->Authorization->authorize($article, 'edit');
+ *     $articles = $this->Authorization->applyScope($query, 'index');
+ *
+ * Both forms dispatch to this policy, which in turn asks
+ * {@see \TinyAuthBackend\Service\TinyAuthService} to resolve the rules
+ * against the DB-managed tables.
+ *
+ * ### Method contract
+ *
+ * All `can*()` and `scope*()` methods accept a nullable
+ * `Authorization\IdentityInterface`, matching CakePHP Authorization's
+ * calling convention. The identity's original data is expected to be
+ * a Cake entity (loaded by `AuthenticationMiddleware` or by a custom
+ * middleware in the app). Null identities always deny.
+ *
+ * ### Custom abilities
+ *
+ * Custom ability names (`canPublish`, `canArchive`, ...) work
+ * out-of-the-box via `__call`. The ability string passed to the
+ * underlying service is the lowercase-first suffix, so `canPublish`
+ * becomes ability `publish`.
  */
 class TinyAuthPolicy implements BeforePolicyInterface {
 
@@ -48,35 +76,35 @@ class TinyAuthPolicy implements BeforePolicyInterface {
 	 * @return bool|null True to allow, false to deny, null to continue to specific checks.
 	 */
 	public function before(?IdentityInterface $identity, mixed $resource, string $action): ?bool {
-		if (!$identity) {
+		$user = $this->resolveUser($identity);
+		if ($user === null) {
 			return false;
 		}
 
-		$user = $identity->getOriginalData();
-		if (!$user instanceof EntityInterface) {
-			return false;
-		}
-
-		// Get user roles
 		$roles = $this->tinyAuth->getUserRoles($user);
-
-		// Super admin bypass
 		if (array_intersect($roles, $this->getSuperAdminRoles())) {
 			return true;
 		}
 
-		return null; // Continue to specific checks
+		return null;
 	}
 
 	/**
-	 * Generic can check for any ability.
+	 * Generic can check for any ability. Kept public so custom
+	 * subclasses can delegate to it without reimplementing the
+	 * role/resource plumbing.
 	 *
-	 * @param \Cake\Datasource\EntityInterface $user The user entity.
+	 * @param \Authorization\IdentityInterface|null $identity The identity.
 	 * @param string $ability The ability to check (view, edit, delete, etc.).
 	 * @param \Cake\Datasource\EntityInterface $entity The entity being accessed.
 	 * @return bool Whether access is allowed.
 	 */
-	public function can(EntityInterface $user, string $ability, EntityInterface $entity): bool {
+	public function can(?IdentityInterface $identity, string $ability, EntityInterface $entity): bool {
+		$user = $this->resolveUser($identity);
+		if ($user === null) {
+			return false;
+		}
+
 		$resource = $this->getResourceName($entity);
 		$roles = $this->tinyAuth->getUserRoles($user);
 
@@ -90,54 +118,50 @@ class TinyAuthPolicy implements BeforePolicyInterface {
 	}
 
 	/**
-	 * Check if user can view the entity.
-	 *
-	 * @param \Cake\Datasource\EntityInterface $user The user entity.
-	 * @param \Cake\Datasource\EntityInterface $entity The entity being accessed.
-	 * @return bool Whether access is allowed.
+	 * @param \Authorization\IdentityInterface|null $identity
+	 * @param \Cake\Datasource\EntityInterface $entity
+	 * @return bool
 	 */
-	public function canView(EntityInterface $user, EntityInterface $entity): bool {
-		return $this->can($user, 'view', $entity);
+	public function canView(?IdentityInterface $identity, EntityInterface $entity): bool {
+		return $this->can($identity, 'view', $entity);
 	}
 
 	/**
-	 * Check if user can create entities of this type.
+	 * Check if the user can create entities of this type.
 	 * Note: Entity is the prototype/empty entity being created.
 	 *
-	 * @param \Cake\Datasource\EntityInterface $user The user entity.
-	 * @param \Cake\Datasource\EntityInterface $entity The entity being created.
-	 * @return bool Whether access is allowed.
+	 * @param \Authorization\IdentityInterface|null $identity
+	 * @param \Cake\Datasource\EntityInterface $entity
+	 * @return bool
 	 */
-	public function canCreate(EntityInterface $user, EntityInterface $entity): bool {
-		return $this->can($user, 'create', $entity);
+	public function canCreate(?IdentityInterface $identity, EntityInterface $entity): bool {
+		return $this->can($identity, 'create', $entity);
 	}
 
 	/**
-	 * Check if user can edit the entity.
-	 *
-	 * @param \Cake\Datasource\EntityInterface $user The user entity.
-	 * @param \Cake\Datasource\EntityInterface $entity The entity being edited.
-	 * @return bool Whether access is allowed.
+	 * @param \Authorization\IdentityInterface|null $identity
+	 * @param \Cake\Datasource\EntityInterface $entity
+	 * @return bool
 	 */
-	public function canEdit(EntityInterface $user, EntityInterface $entity): bool {
-		return $this->can($user, 'edit', $entity);
+	public function canEdit(?IdentityInterface $identity, EntityInterface $entity): bool {
+		return $this->can($identity, 'edit', $entity);
 	}
 
 	/**
-	 * Check if user can delete the entity.
-	 *
-	 * @param \Cake\Datasource\EntityInterface $user The user entity.
-	 * @param \Cake\Datasource\EntityInterface $entity The entity being deleted.
-	 * @return bool Whether access is allowed.
+	 * @param \Authorization\IdentityInterface|null $identity
+	 * @param \Cake\Datasource\EntityInterface $entity
+	 * @return bool
 	 */
-	public function canDelete(EntityInterface $user, EntityInterface $entity): bool {
-		return $this->can($user, 'delete', $entity);
+	public function canDelete(?IdentityInterface $identity, EntityInterface $entity): bool {
+		return $this->can($identity, 'delete', $entity);
 	}
 
 	/**
 	 * Magic method handler for custom abilities.
 	 *
-	 * Allows calling canPublish(), canArchive(), etc. without defining each method.
+	 * Allows calling `canPublish()`, `canArchive()`, etc. without
+	 * defining each method. The ability name is the lowercase-first
+	 * suffix (`canPublish` → `publish`).
 	 *
 	 * @param string $method The method name being called.
 	 * @param array<mixed> $args The method arguments.
@@ -147,17 +171,156 @@ class TinyAuthPolicy implements BeforePolicyInterface {
 	public function __call(string $method, array $args): bool {
 		if (str_starts_with($method, 'can')) {
 			$ability = lcfirst(substr($method, 3)); // canPublish -> publish
-
 			if (count($args) < 2) {
 				throw new BadMethodCallException(
-					"Method {$method} requires user and entity arguments.",
+					"Method {$method} requires identity and entity arguments.",
 				);
 			}
 
-			return $this->can($args[0], $ability, $args[1]);
+			/** @var \Authorization\IdentityInterface|null $identity */
+			$identity = $args[0];
+			/** @var \Cake\Datasource\EntityInterface $entity */
+			$entity = $args[1];
+
+			return $this->can($identity, $ability, $entity);
 		}
 
 		throw new BadMethodCallException("Unknown method: {$method}");
+	}
+
+	/**
+	 * Default scope for list/index queries — applies the effective
+	 * `getScopeCondition()` from TinyAuthService to the query. Used
+	 * by `$this->Authorization->applyScope($query, 'index')`.
+	 *
+	 * Tri-state handling mirrors what `TinyAuthService::getScopeCondition()`
+	 * returns:
+	 *
+	 *   - `null` → no access; query is forced empty (`1 = 0`).
+	 *   - `[]` → full access; query is returned untouched.
+	 *   - `[...]` → scoped access; conditions are applied, with the
+	 *                table alias prepended and null values translated
+	 *                to `IS NULL`.
+	 *
+	 * Super-admin roles bypass scoping entirely.
+	 *
+	 * @param \Authorization\IdentityInterface|null $identity
+	 * @param \Cake\ORM\Query\SelectQuery<\Cake\Datasource\EntityInterface> $query
+	 * @return \Cake\ORM\Query\SelectQuery<\Cake\Datasource\EntityInterface>
+	 */
+	public function scopeIndex(?IdentityInterface $identity, SelectQuery $query): SelectQuery {
+		return $this->applyScopeConditions($identity, $query, 'view');
+	}
+
+	/**
+	 * Alias of `scopeIndex()` — useful when `applyScope($query, 'view')`
+	 * is used instead of the default `index` action name.
+	 *
+	 * @param \Authorization\IdentityInterface|null $identity
+	 * @param \Cake\ORM\Query\SelectQuery<\Cake\Datasource\EntityInterface> $query
+	 * @return \Cake\ORM\Query\SelectQuery<\Cake\Datasource\EntityInterface>
+	 */
+	public function scopeView(?IdentityInterface $identity, SelectQuery $query): SelectQuery {
+		return $this->applyScopeConditions($identity, $query, 'view');
+	}
+
+	/**
+	 * Apply `TinyAuthService::getScopeCondition()` to the given query
+	 * for the given ability.
+	 *
+	 * @param \Authorization\IdentityInterface|null $identity
+	 * @param \Cake\ORM\Query\SelectQuery<\Cake\Datasource\EntityInterface> $query
+	 * @param string $ability
+	 * @return \Cake\ORM\Query\SelectQuery<\Cake\Datasource\EntityInterface>
+	 */
+	protected function applyScopeConditions(?IdentityInterface $identity, SelectQuery $query, string $ability): SelectQuery {
+		$user = $this->resolveUser($identity);
+		if ($user === null) {
+			return $query->where(['1 = 0']);
+		}
+
+		$roles = $this->tinyAuth->getUserRoles($user);
+		if (array_intersect($roles, $this->getSuperAdminRoles())) {
+			return $query;
+		}
+
+		$resource = $this->resourceForQuery($query);
+		$conditions = $this->tinyAuth->getScopeCondition($roles, $resource, $ability, $user);
+
+		if ($conditions === null) {
+			return $query->where(['1 = 0']);
+		}
+		if ($conditions === []) {
+			return $query;
+		}
+
+		return $query->where($this->qualifyConditions($conditions, $query));
+	}
+
+	/**
+	 * Resolve the wrapped Cake entity out of an Authorization identity.
+	 * Returns null when the identity is missing or carries non-entity
+	 * data, which short-circuits every check to a deny.
+	 *
+	 * @param \Authorization\IdentityInterface|null $identity
+	 * @return \Cake\Datasource\EntityInterface|null
+	 */
+	protected function resolveUser(?IdentityInterface $identity): ?EntityInterface {
+		if ($identity === null) {
+			return null;
+		}
+		$data = $identity->getOriginalData();
+		if (!$data instanceof EntityInterface) {
+			return null;
+		}
+
+		return $data;
+	}
+
+	/**
+	 * Derive the resource class name from a query. Uses the
+	 * repository's configured entity class so the lookup matches how
+	 * single-entity checks via `can()` resolve their resource.
+	 *
+	 * @param \Cake\ORM\Query\SelectQuery<\Cake\Datasource\EntityInterface> $query
+	 * @return string
+	 */
+	protected function resourceForQuery(SelectQuery $query): string {
+		return $query->getRepository()->getEntityClass();
+	}
+
+	/**
+	 * Table-qualify scope conditions so they don't collide with joined
+	 * tables, and translate explicit nulls into `field IS` form.
+	 *
+	 * @param array<string, mixed> $conditions
+	 * @param \Cake\ORM\Query\SelectQuery<\Cake\Datasource\EntityInterface> $query
+	 * @return array<string, mixed>
+	 */
+	protected function qualifyConditions(array $conditions, SelectQuery $query): array {
+		$alias = $query->getRepository()->getAlias();
+
+		$out = [];
+		foreach ($conditions as $field => $value) {
+			if ($field === 'OR' || $field === 'AND') {
+				$out[$field] = array_map(
+					fn ($sub) => is_array($sub) ? $this->qualifyConditions($sub, $query) : $sub,
+					(array)$value,
+				);
+
+				continue;
+			}
+
+			$qualified = str_contains((string)$field, '.') ? (string)$field : $alias . '.' . $field;
+
+			if ($value === null) {
+				$out[$qualified . ' IS'] = null;
+			} else {
+				$out[$qualified] = $value;
+			}
+		}
+
+		return $out;
 	}
 
 	/**

--- a/tests/TestCase/Policy/TinyAuthPolicyTest.php
+++ b/tests/TestCase/Policy/TinyAuthPolicyTest.php
@@ -66,12 +66,98 @@ class TinyAuthPolicyTest extends TestCase {
 
 	public function testCanEditUsesSyncedResourceName(): void {
 		$policy = new TinyAuthPolicy();
-		$user = new Entity(['id' => 99, 'role_id' => 1]);
+		$identity = new TestIdentity(new Entity(['id' => 99, 'role_id' => 1]));
 		$article = new Article(['id' => 5, 'user_id' => 99]);
 
-		$result = $policy->canEdit($user, $article);
+		$result = $policy->canEdit($identity, $article);
 
 		$this->assertTrue($result);
+	}
+
+	/**
+	 * Null identity must deny every check — guards against a silent
+	 * passthrough from missing authentication.
+	 *
+	 * @return void
+	 */
+	public function testCanEditDeniesNullIdentity(): void {
+		$policy = new TinyAuthPolicy();
+
+		$this->assertFalse($policy->canEdit(null, new Article(['id' => 5, 'user_id' => 99])));
+		$this->assertFalse($policy->canView(null, new Article(['id' => 5, 'user_id' => 99])));
+		$this->assertFalse($policy->canDelete(null, new Article(['id' => 5, 'user_id' => 99])));
+	}
+
+	/**
+	 * Custom abilities via __call must also accept an identity and
+	 * pass the unwrapped user to TinyAuthService.
+	 *
+	 * @return void
+	 */
+	/**
+	 * Null identity forces the query to `1 = 0` — no rows leak to
+	 * anonymous visitors even on list endpoints.
+	 *
+	 * @return void
+	 */
+	public function testScopeIndexDeniesNullIdentity(): void {
+		$this->insertRow('tinyauth_roles', [
+			'id' => 99,
+			'name' => 'Dummy',
+			'alias' => 'dummy',
+			'parent_id' => null,
+			'sort_order' => 9999,
+		]);
+		// A freshly-created table with a known schema avoids schema
+		// introspection errors on test_app Tables we don't ship a
+		// fixture for.
+		$table = $this->fetchTable('TinyAuthBackend.Roles');
+		$query = $table->find();
+
+		$policy = new TinyAuthPolicy();
+		$result = $policy->scopeIndex(null, $query);
+
+		$this->assertStringContainsString('1 = 0', $result->sql());
+	}
+
+	/**
+	 * Super-admin identity returns the query unchanged — no WHERE
+	 * narrowing, full access.
+	 *
+	 * @return void
+	 */
+	public function testScopeIndexSuperAdminBypass(): void {
+		Configure::write('TinyAuth.superAdminRole', 'admin');
+
+		$policy = new TinyAuthPolicy();
+		$identity = new TestIdentity(new Entity(['id' => 1, 'role_id' => 1]));
+		$query = $this->fetchTable('TinyAuthBackend.Roles')->find();
+
+		$result = $policy->scopeIndex($identity, $query);
+
+		$this->assertSame($query, $result);
+	}
+
+	public function testCustomAbilityViaCallAcceptsIdentity(): void {
+		$this->insertRow('tinyauth_resource_abilities', [
+			'id' => 2,
+			'resource_id' => 1,
+			'name' => 'publish',
+			'description' => null,
+		]);
+		$this->insertRow('tinyauth_resource_acl', [
+			'id' => 2,
+			'resource_ability_id' => 2,
+			'role_id' => 1,
+			'type' => 'allow',
+			'scope_id' => null,
+		]);
+
+		$policy = new TinyAuthPolicy();
+		$identity = new TestIdentity(new Entity(['id' => 99, 'role_id' => 1]));
+		$article = new Article(['id' => 5, 'user_id' => 99]);
+
+		$this->assertTrue($policy->canPublish($identity, $article));
 	}
 
 	public function testBeforeUsesConfiguredSuperAdminRole(): void {


### PR DESCRIPTION
## Summary

Three fixes surfaced while wiring the plugin into a standalone demo app (\`cakephp-tinyauth-demo\`) with the Authorization plugin as the runtime entry point. All three are bugs you hit the moment you actually use \`\$this->Authorization->authorize(\$entity)\` or \`->applyScope(\$query)\` against a TinyAuth-managed resource, which is what \`TinyAuthPolicy\` is advertised for.

### 1. \`TinyAuthPolicy\`: accept \`?IdentityInterface\` instead of \`EntityInterface\`

Every \`can*()\` method previously declared \`EntityInterface \$user\` as its first argument, but \`cakephp/authorization\`'s \`AuthorizationService::performCheck\` passes the policy a \`?IdentityInterface\` — not the raw user entity. Calling \`\$this->Authorization->authorize(\$article, 'view')\` against the old signature fatally TypeError'd on the very first use:

~~~
TypeError: canView(): Argument #1 must be EntityInterface, IdentityInterface given
~~~

Methods are now \`(?IdentityInterface \$identity, EntityInterface \$entity)\` matching the plugin contract. Each check delegates to a new \`resolveUser()\` helper that unwraps \`getOriginalData()\` and returns \`null\` for missing-or-non-entity identities, which short-circuits every check to a deny. \`before()\` uses the same helper so its super-admin bypass behaves consistently.

\`__call\` is updated so custom abilities (\`canPublish\`, \`canArchive\`, …) also receive \`?IdentityInterface\` and route through the new signature.

**Why nullable first** (common review question): it's not a style choice — \`AuthorizationService::performCheck\` declares \`?IdentityInterface \$user\`, so null is a first-class case that happens on every anonymous request. Non-nullable would fatal-error on any \`authorize()\` call without an active identity, and the canonical pattern in every Authorization-plugin policy is for the policy to accept \`null\` and return \`false\` (deny).

### 2. \`TinyAuthPolicy\`: add \`scope*()\` methods

The upstream policy had no \`scope*()\` methods, so \`\$this->Authorization->applyScope(\$query)\` could not run against TinyAuth-managed entities — a real-world adopter wanting list-page scoping had to write a parallel policy.

This PR adds \`scopeIndex()\` and \`scopeView()\` that bridge to \`TinyAuthService::getScopeCondition()\` with the tri-state handling that method returns:

- \`null\` → no access; the query is forced empty via \`WHERE 1 = 0\` so no rows leak (e.g. unauthenticated / unmatched role)
- \`[]\` → full access; the query is returned untouched
- \`[...]\` → scoped access; conditions are applied, with the repository alias prepended and explicit nulls translated to \`field IS\`

Super-admin roles bypass scope narrowing entirely. Null identity is denied at the top and produces an empty query. Both paths are covered by new tests.

Controllers can now write idiomatic:

~~~php
public function index(): void
{
    \$query = \$this->fetchTable('Articles')->find();
    \$articles = \$this->Authorization->applyScope(\$query, 'index')->all();
    \$this->set(compact('articles'));
}
~~~

without any custom policy code.

### 3. \`ResourcesController\`: MySQL LIKE backslash escape

When \`TinyAuthBackend.resourceNamespaceFilter\` is set to a PHP namespace like \`'App\\\\'\`, the resulting query was:

~~~sql
WHERE entity_class LIKE 'App\\%'
~~~

MySQL's LIKE treats backslash as its escape character by default, so \`\\%\` means "literal percent sign" — the filter matched the literal string \`App%\` and returned zero rows. This is why the admin Resources panel showed empty for any non-null filter value (which, until #17 defaulted it to \`null\`, was the default).

Fix: double-escape backslashes in the pattern before passing it to LIKE:

~~~php
\$pattern = str_replace('\\\\', '\\\\\\\\', \$namespaceFilter) . '%';
~~~

Other drivers pass the value through unchanged.

## Tests

- New: null identity denies every \`can*\` check
- New: \`scopeIndex\` forces \`1 = 0\` on null identity
- New: \`scopeIndex\` returns query unchanged for super-admin role
- New: custom ability via \`__call\` accepts \`?IdentityInterface\`
- Existing \`testCanEditUsesSyncedResourceName\` updated to pass \`TestIdentity\`
- **All gates green: 71 tests / 153 assertions, PHPCS clean, PHPStan clean.**

## Backwards compatibility

- **\`can*()\` / \`before()\` signatures change**: any custom subclass that overrode \`canEdit(EntityInterface \$user, …)\` will need to update to \`canEdit(?IdentityInterface \$identity, …)\`. This is a mechanical rename + an internal call to \`getOriginalData()\` if the subclass needs the entity. Given the old signature was effectively unusable with the Authorization plugin, I don't expect real-world subclasses to exist.
- **New \`scope*\` methods are additive** — no existing code breaks.
- **Namespace filter fix is pure bug-fix** — previously zero rows matched any non-null filter; now matching rows are returned.