### PR TITLE
Defense-in-depth authz hook + misc security polish

### DIFF
--- a/config/bootstrap.php
+++ b/config/bootstrap.php
@@ -2,9 +2,12 @@
 declare(strict_types=1);
 
 use Cake\Core\Configure;
+use Cake\Utility\Hash;
 
-// Default configuration
-Configure::write('TinyAuthBackend', [
+// Default configuration. Merged with any TinyAuthBackend.* values the
+// host app already set so callers can pre-seed keys (e.g. editorCheck)
+// before the plugin bootstraps without having them wiped.
+$defaults = [
 	'roleHierarchy' => true,
 	'multiRole' => false, // Set true for users with multiple roles
 	'roleColumn' => 'role_id', // Single role: column name
@@ -43,4 +46,9 @@ Configure::write('TinyAuthBackend', [
 	// Plugins to exclude from ACL controller tree in admin panel
 	// These plugins won't appear in the permission management UI
 	'excludedPlugins' => ['DebugKit', 'TinyAuthBackend'],
-]);
+];
+
+Configure::write(
+	'TinyAuthBackend',
+	Hash::merge($defaults, (array)Configure::read('TinyAuthBackend')),
+);

--- a/src/Auth/AclAdapter/CompositeAclAdapter.php
+++ b/src/Auth/AclAdapter/CompositeAclAdapter.php
@@ -64,10 +64,11 @@ class CompositeAclAdapter implements AclAdapterInterface {
 				$adapter = new $adapterClass();
 				$contribution = $adapter->getAcl($availableRoles, $config);
 			} catch (Throwable $e) {
+				$shortName = strrchr($adapterClass, '\\');
 				Log::warning(sprintf(
-					'CompositeAclAdapter skipped delegated adapter "%s" after exception: %s',
-					$adapterClass,
-					$e->getMessage(),
+					'CompositeAclAdapter skipped delegated adapter "%s" after %s',
+					$shortName !== false ? substr($shortName, 1) : $adapterClass,
+					$e::class,
 				));
 
 				continue;

--- a/src/Auth/AllowAdapter/CompositeAllowAdapter.php
+++ b/src/Auth/AllowAdapter/CompositeAllowAdapter.php
@@ -75,10 +75,11 @@ class CompositeAllowAdapter implements AllowAdapterInterface {
 				$adapter = new $adapterClass();
 				$contribution = $adapter->getAllow($config);
 			} catch (Throwable $e) {
+				$shortName = strrchr($adapterClass, '\\');
 				Log::warning(sprintf(
-					'CompositeAllowAdapter skipped delegated adapter "%s" after exception: %s',
-					$adapterClass,
-					$e->getMessage(),
+					'CompositeAllowAdapter skipped delegated adapter "%s" after %s',
+					$shortName !== false ? substr($shortName, 1) : $adapterClass,
+					$e::class,
 				));
 
 				continue;

--- a/src/Controller/Admin/AclController.php
+++ b/src/Controller/Admin/AclController.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 namespace TinyAuthBackend\Controller\Admin;
 
 use Cake\Core\Configure;
+use Cake\Datasource\EntityInterface;
 use Cake\Http\Exception\BadRequestException;
 use Cake\Http\Response;
 use TinyAuthBackend\Service\HierarchyService;
@@ -120,18 +121,32 @@ class AclController extends AppController {
 			$controllersTable = $this->fetchTable('TinyAuthBackend.TinyauthControllers');
 			$actionsTable = $this->fetchTable('TinyAuthBackend.Actions');
 
-			$results['controllers'] = $controllersTable->find()
-				->where(['name LIKE' => "%{$q}%"])
-				->limit(5)
-				->all()
-				->toArray();
+			// Filter in PHP instead of via SQL LIKE so that user-supplied
+			// `_` / `%` match literally and not as LIKE wildcards. The
+			// admin matrix tables are bounded (one row per controller /
+			// action of the host app) so a full scan is cheap and avoids
+			// per-database ESCAPE clause quirks.
+			$needle = mb_strtolower($q);
+			$match = function (EntityInterface|array $row) use ($needle): bool {
+				$name = $row instanceof EntityInterface ? $row->get('name') : ($row['name'] ?? '');
 
-			$results['actions'] = $actionsTable->find()
-				->contain(['TinyauthControllers'])
-				->where(['Actions.name LIKE' => "%{$q}%"])
-				->limit(5)
-				->all()
-				->toArray();
+				return str_contains(mb_strtolower((string)$name), $needle);
+			};
+
+			$results['controllers'] = array_slice(
+				array_values(array_filter($controllersTable->find()->all()->toArray(), $match)),
+				0,
+				5,
+			);
+
+			$results['actions'] = array_slice(
+				array_values(array_filter(
+					$actionsTable->find()->contain(['TinyauthControllers'])->all()->toArray(),
+					$match,
+				)),
+				0,
+				5,
+			);
 
 			$roles = (new RoleSourceService())->getRoleEntities();
 			$results['roles'] = array_slice(array_values(array_filter($roles, function (object $role) use ($q): bool {

--- a/src/Controller/Admin/AppController.php
+++ b/src/Controller/Admin/AppController.php
@@ -4,6 +4,9 @@ declare(strict_types=1);
 namespace TinyAuthBackend\Controller\Admin;
 
 use Cake\Controller\Controller;
+use Cake\Core\Configure;
+use Cake\Event\EventInterface;
+use Cake\Http\Exception\ForbiddenException;
 
 /**
  * Base controller for TinyAuthBackend Admin controllers.
@@ -17,6 +20,51 @@ class AppController extends Controller {
 		parent::initialize();
 		$this->viewBuilder()->setLayout('TinyAuthBackend.tinyauth');
 		$this->loadComponent('Flash');
+	}
+
+	/**
+	 * Defense-in-depth authorization hook.
+	 *
+	 * The plugin delegates authentication to the host app — the
+	 * `/admin/auth` prefix is expected to be gated at the middleware or
+	 * routing layer. This hook adds an optional *authorization* gate so
+	 * the plugin can reject authenticated-but-not-privileged users (e.g.
+	 * a helpdesk identity that can see the admin area but must not be
+	 * able to edit ACL rules).
+	 *
+	 * Configure a callable under `TinyAuthBackend.editorCheck` that
+	 * receives the current identity (may be `null`) and the request, and
+	 * returns `true` if the caller is permitted to manage TinyAuth rules.
+	 * Returning `false` — or any non-true value — raises a 403.
+	 *
+	 * ```php
+	 * Configure::write('TinyAuthBackend.editorCheck', function ($identity, $request) {
+	 *     return $identity !== null && in_array('admin', (array)$identity->roles, true);
+	 * });
+	 * ```
+	 *
+	 * When the key is unset the hook is a no-op — existing installs keep
+	 * working and continue to rely on the host app's gating.
+	 *
+     * @param \Cake\Event\EventInterface<\Cake\Controller\Controller> $event
+     * @throws \Cake\Http\Exception\ForbiddenException When the configured check rejects the caller.
+     * @return void
+	 */
+	public function beforeFilter(EventInterface $event): void {
+		parent::beforeFilter($event);
+
+		$check = Configure::read('TinyAuthBackend.editorCheck');
+		if ($check === null) {
+			return;
+		}
+		if (!is_callable($check)) {
+			throw new ForbiddenException('TinyAuthBackend.editorCheck must be callable');
+		}
+
+		$identity = $this->request->getAttribute('identity');
+		if ($check($identity, $this->request) !== true) {
+			throw new ForbiddenException('Not authorized to manage TinyAuth rules');
+		}
 	}
 
 }

--- a/tests/TestCase/Controller/Admin/AclControllerTest.php
+++ b/tests/TestCase/Controller/Admin/AclControllerTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 namespace TinyAuthBackend\Test\TestCase\Controller\Admin;
 
 use Cake\Core\Configure;
+use Cake\Http\Exception\ForbiddenException;
 use Cake\TestSuite\IntegrationTestTrait;
 use Cake\TestSuite\TestCase;
 use TinyAuthBackend\Auth\AclAdapter\DbAclAdapter;
@@ -200,7 +201,7 @@ class AclControllerTest extends TestCase {
 		$this->disableErrorHandlerMiddleware();
 		Configure::write('TinyAuthBackend.editorCheck', fn ($identity, $request) => false);
 
-		$this->expectException(\Cake\Http\Exception\ForbiddenException::class);
+		$this->expectException(ForbiddenException::class);
 		$this->post(['prefix' => 'Admin', 'plugin' => 'TinyAuthBackend', 'controller' => 'Acl', 'action' => 'toggle'], [
 			'action_id' => 1,
 			'role_id' => 1,

--- a/tests/TestCase/Controller/Admin/AclControllerTest.php
+++ b/tests/TestCase/Controller/Admin/AclControllerTest.php
@@ -28,6 +28,7 @@ class AclControllerTest extends TestCase {
 		$this->loadPlugins(['TinyAuthBackend']);
 		Configure::write('TinyAuth.aclAdapter', DbAclAdapter::class);
 		Configure::write('TinyAuthBackend.roleSource', null);
+		Configure::delete('TinyAuthBackend.editorCheck');
 		(new RoleSourceService())->clearCache();
 
 		$this->insertRow('tinyauth_roles', [
@@ -164,6 +165,60 @@ class AclControllerTest extends TestCase {
 
 		$this->assertResponseCode(200);
 		$this->assertResponseContains('index');
+	}
+
+	public function testSearchTreatsUnderscoreAsLiteralNotWildcard(): void {
+		// Sibling controller with a name that SQL LIKE's `_` wildcard
+		// would match if the query were passed through unescaped.
+		$this->insertRow('tinyauth_controllers', [
+			'id' => 2,
+			'plugin' => null,
+			'prefix' => 'Admin',
+			'name' => 'AXBooks',
+		]);
+		$this->insertRow('tinyauth_controllers', [
+			'id' => 3,
+			'plugin' => null,
+			'prefix' => 'Admin',
+			'name' => 'A_Books',
+		]);
+
+		$this->get(['prefix' => 'Admin', 'plugin' => 'TinyAuthBackend', 'controller' => 'Acl', 'action' => 'search', '?' => ['q' => 'A_B']]);
+
+		$this->assertResponseCode(200);
+		$this->assertResponseContains('A_Books');
+		$this->assertResponseNotContains('AXBooks');
+	}
+
+	public function testEditorCheckUnsetAllowsRequest(): void {
+		$this->get(['prefix' => 'Admin', 'plugin' => 'TinyAuthBackend', 'controller' => 'Acl', '?' => ['controller_id' => 1]]);
+
+		$this->assertResponseCode(200);
+	}
+
+	public function testEditorCheckRejectsUnprivilegedCaller(): void {
+		$this->disableErrorHandlerMiddleware();
+		Configure::write('TinyAuthBackend.editorCheck', fn ($identity, $request) => false);
+
+		$this->expectException(\Cake\Http\Exception\ForbiddenException::class);
+		$this->post(['prefix' => 'Admin', 'plugin' => 'TinyAuthBackend', 'controller' => 'Acl', 'action' => 'toggle'], [
+			'action_id' => 1,
+			'role_id' => 1,
+			'type' => 'allow',
+		]);
+	}
+
+	public function testEditorCheckAllowsPrivilegedCaller(): void {
+		Configure::write('TinyAuthBackend.editorCheck', fn ($identity, $request) => true);
+
+		$this->post(['prefix' => 'Admin', 'plugin' => 'TinyAuthBackend', 'controller' => 'Acl', 'action' => 'toggle'], [
+			'action_id' => 1,
+			'role_id' => 1,
+			'type' => 'allow',
+		]);
+
+		$this->assertResponseCode(200);
+		$this->assertSame(1, $this->countRows('tinyauth_acl_permissions', ['action_id' => 1, 'role_id' => 1, 'type' => 'allow']));
 	}
 
 }


### PR DESCRIPTION
Follow-up from a plugin security audit. None of these are remote-exploit
grade on their own, but together they make the plugin safer by default
for downstream users who may not have a tightly-gated admin prefix.

## 1. Optional `TinyAuthBackend.editorCheck` callable

`Admin\AppController` now has a `beforeFilter` that invokes a
configurable editor-check closure and throws a 403 if it does not
return `true`. When the key is unset (default) it is a no-op, so
existing installs keep working and continue to rely on the host app to
gate `/admin/auth`.

The check accepts `(identity, request)` and can do whatever the host
wants — role membership, capability flags, remote-address allow-lists,
etc.

~~~php
Configure::write('TinyAuthBackend.editorCheck', function ($identity, $request) {
    return $identity !== null && in_array('admin', (array)$identity->roles, true);
});
~~~

This closes the gap where an authenticated-but-lower-privileged user
(helpdesk, read-only operator, etc.) who reaches `/admin/auth` via the
host's coarse "logged in = admin area" gating could previously toggle
any ACL rule and self-escalate.

## 2. Plugin bootstrap merges instead of replaces

`config/bootstrap.php` previously did `Configure::write('TinyAuthBackend',
[...big default array...])` which wholesale-replaced anything a caller
had already written under that key. That meant pre-seeding any
`TinyAuthBackend.*` config before the plugin booted silently lost the
value. Now the defaults are `Hash::merge`'d with the existing value, so
callers can set `editorCheck` (or any other key) before or after plugin
boot and it sticks.

Also fixes a test-only footgun: the integration test harness calls
`BaseApplication::bootstrap()` which `require_once`s `config/bootstrap.php`,
so writes made by the test body were being wiped on the first dispatch
of each test run.

## 3. `AclController::search()` filters in PHP instead of SQL LIKE

The search endpoint was building `LIKE` patterns via direct
interpolation of the user-supplied `q` into `%{$q}%`. The ORM
parameterized it so it wasn't SQL injection, but `_` and `%` leaked
through as `LIKE` wildcards — a crafted `q` of `a_min` would match
`admin`, `a1min`, etc., letting an attacker enumerate rows faster than
intended.

Rather than bolt on cross-database `ESCAPE` clause handling (SQLite,
MySQL and Postgres all differ on whether backslash is an escape char
by default), just fetch the bounded admin matrix tables and filter in
PHP with `str_contains`. The controllers/actions tables are one row per
host-app controller/action, so a full scan is cheap and obviously
correct.

## 4. Composite adapter log messages trimmed

`Log::warning()` in `CompositeAllowAdapter`/`CompositeAclAdapter`
previously included the full adapter FQCN and raw exception message,
which leak internal namespaces and potentially SQL / path fragments to
any log reader. Shortened to the class basename and the exception class
only.

## Tests

`tests/TestCase/Controller/Admin/AclControllerTest` gets four new
cases:

- `testSearchTreatsUnderscoreAsLiteralNotWildcard` — inserts two sibling
  rows (`A_Books`, `AXBooks`), searches `A_B`, asserts only the
  literal match comes back.
- `testEditorCheckUnsetAllowsRequest` — back-compat path.
- `testEditorCheckRejectsUnprivilegedCaller` — 403 when callable returns
  false.
- `testEditorCheckAllowsPrivilegedCaller` — 200 when callable returns
  true.

75 tests pass, phpstan clean, phpcs clean.