### PR TITLE
Add TinyAuthResolver and EntityIdentity for Authorization integration

### DIFF
--- a/docs/Authorization.md
+++ b/docs/Authorization.md
@@ -29,27 +29,37 @@ Load the plugin and middleware in your app as usual.
 
 ### Mapping `TinyAuthPolicy`
 
-Map it as the default policy for entities you want to control from the backend:
+The plugin ships a dedicated `TinyAuthResolver` that maps any known entity, table, or `SelectQuery` to `TinyAuthPolicy` — without you having to write a thin `App\Policy\FooPolicy` wrapper per resource:
 
 ```php
 use Authorization\AuthorizationService;
 use Authorization\AuthorizationServiceInterface;
 use Authorization\AuthorizationServiceProviderInterface;
-use Authorization\Policy\OrmResolver;
 use Psr\Http\Message\ServerRequestInterface;
-use TinyAuthBackend\Policy\TinyAuthPolicy;
+use TinyAuthBackend\Policy\TinyAuthResolver;
 
 class Application extends BaseApplication implements AuthorizationServiceProviderInterface
 {
     public function getAuthorizationService(
         ServerRequestInterface $request
     ): AuthorizationServiceInterface {
-        $resolver = new OrmResolver(TinyAuthPolicy::class);
+        $resolver = new TinyAuthResolver([
+            \App\Model\Entity\Article::class,
+            \App\Model\Entity\Project::class,
+        ]);
 
         return new AuthorizationService($resolver);
     }
 }
 ```
+
+The constructor takes an allowlist of entity/table classes. Leave it empty to put every resource under TinyAuth control (match-all mode):
+
+```php
+$resolver = new TinyAuthResolver(); // governs all resources
+```
+
+`TinyAuthResolver` transparently unwraps `SelectQuery` instances to their repository, so the same resolver works for both `$this->Authorization->authorize($article, 'edit')` and `$this->Authorization->applyScope($query)`. Cake's built-in `MapResolver` only handles the former, and `OrmResolver` requires convention-based `App\Policy\*` classes — `TinyAuthResolver` avoids both pitfalls.
 
 ### In Controllers
 
@@ -82,6 +92,21 @@ If no config is set, the built-in fallback aliases are:
 
 - `admin`
 - `superadmin`
+
+### Identity Without `cakephp/authentication`
+
+Most apps load `cakephp/authentication`, which hangs an `IdentityInterface` on the request automatically. If your app resolves users another way — a session payload, a JWT claim, an upstream SSO gateway — the plugin ships `EntityIdentity`, a small wrapper that turns any Cake entity into a valid `Authorization\IdentityInterface` without pulling in the authentication plugin:
+
+```php
+use TinyAuthBackend\Identity\EntityIdentity;
+
+$user = $this->Users->get($userId);
+$identity = new EntityIdentity($user, $authorizationService); // service is optional
+
+$request = $request->withAttribute('identity', $identity);
+```
+
+`EntityIdentity` forwards array access and magic property reads to the underlying entity, so policies and templates can treat it interchangeably with the wrapped user entity. When constructed without an authorization service, `can()` returns `false` and `applyScope()` returns the resource unchanged — the right behavior for strategies that gate by role only and never call into the Authorization service (see the AdapterOnly usage pattern).
 
 ### Using `TinyAuthService` Directly
 

--- a/src/Command/ImportCommand.php
+++ b/src/Command/ImportCommand.php
@@ -3,10 +3,10 @@ declare(strict_types=1);
 
 namespace TinyAuthBackend\Command;
 
+use Cake\Command\Command;
 use Cake\Console\Arguments;
 use Cake\Console\ConsoleIo;
 use Cake\Console\ConsoleOptionParser;
-use Cake\Command\Command;
 use Cake\Core\Configure;
 use TinyAuthBackend\Utility\AdapterConfig;
 use TinyAuthBackend\Utility\Importer;

--- a/src/Command/InitCommand.php
+++ b/src/Command/InitCommand.php
@@ -3,10 +3,10 @@ declare(strict_types=1);
 
 namespace TinyAuthBackend\Command;
 
+use Cake\Command\Command;
 use Cake\Console\Arguments;
 use Cake\Console\ConsoleIo;
 use Cake\Console\ConsoleOptionParser;
-use Cake\Command\Command;
 use Cake\Routing\Router;
 use TinyAuth\Utility\TinyAuth;
 use TinyAuthBackend\Utility\Importer;

--- a/src/Identity/EntityIdentity.php
+++ b/src/Identity/EntityIdentity.php
@@ -1,0 +1,163 @@
+<?php
+declare(strict_types=1);
+
+namespace TinyAuthBackend\Identity;
+
+use ArrayAccess;
+use Authorization\AuthorizationServiceInterface;
+use Authorization\IdentityInterface;
+use Authorization\Policy\ResultInterface;
+use BadMethodCallException;
+use Cake\Datasource\EntityInterface;
+
+/**
+ * Lightweight identity wrapper around a Cake ORM entity.
+ *
+ * Implements `Authorization\IdentityInterface` against a plain Cake
+ * entity without requiring `cakephp/authentication`. Useful for apps
+ * that resolve their user from a session, a JWT claim, an upstream
+ * SSO gateway, or any other custom middleware — pass the resulting
+ * entity to this wrapper and drop it on the request under the
+ * configured identity attribute.
+ *
+ * The authorization service is optional. When omitted, the `can*()`
+ * and `applyScope()` methods behave as a no-op (deny / pass-through),
+ * which is the correct behavior for strategies that do not load
+ * `cakephp/authorization` at all (e.g. the AdapterOnly rung). When a
+ * service is provided, the identity delegates to it exactly like the
+ * framework's own `IdentityDecorator`.
+ *
+ * Array-style access (`$identity['id']`, `$identity['role_id']`) is
+ * forwarded to the underlying entity. `__call()` and `__get()`
+ * proxies forward to the entity as well, so template code can treat
+ * the identity interchangeably with the entity it wraps.
+ */
+class EntityIdentity implements IdentityInterface {
+
+	/**
+	 * @var \Cake\Datasource\EntityInterface
+	 */
+	protected EntityInterface $entity;
+
+	/**
+	 * @var \Authorization\AuthorizationServiceInterface|null
+	 */
+	protected ?AuthorizationServiceInterface $service;
+
+	/**
+	 * @param \Cake\Datasource\EntityInterface $entity The user entity.
+	 * @param \Authorization\AuthorizationServiceInterface|null $service Optional authorization service.
+	 */
+	public function __construct(EntityInterface $entity, ?AuthorizationServiceInterface $service = null) {
+		$this->entity = $entity;
+		$this->service = $service;
+	}
+
+	/**
+	 * Return the entity's primary key value.
+	 *
+	 * Mirrors `cakephp/authentication`'s `Identity::getIdentifier()` so
+	 * adopters coming from that plugin have a familiar API.
+	 *
+	 * @return array<array-key, mixed>|string|int|null
+	 */
+	public function getIdentifier(): array|string|int|null {
+		/** @var array<array-key, mixed>|string|int|null $value */
+		$value = $this->entity->get('id');
+
+		return $value;
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public function can(string $action, mixed $resource): bool {
+		return $this->service?->can($this, $action, $resource) ?? false;
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public function canResult(string $action, mixed $resource): ResultInterface {
+		if ($this->service === null) {
+			throw new BadMethodCallException(
+				'EntityIdentity::canResult() requires an AuthorizationService. '
+				. 'Construct EntityIdentity with a service, or call can() instead.',
+			);
+		}
+
+		return $this->service->canResult($this, $action, $resource);
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public function applyScope(string $action, mixed $resource, mixed ...$optionalArgs): mixed {
+		if ($this->service === null) {
+			return $resource;
+		}
+
+		return $this->service->applyScope($this, $action, $resource, ...$optionalArgs);
+	}
+
+	/**
+	 * @return \ArrayAccess<string, mixed>|array<string, mixed>
+	 */
+	public function getOriginalData(): ArrayAccess|array {
+		return $this->entity;
+	}
+
+	/**
+	 * @param mixed $offset
+	 * @return bool
+	 */
+	public function offsetExists(mixed $offset): bool {
+		return $this->entity->offsetExists($offset);
+	}
+
+	/**
+	 * @param mixed $offset
+	 * @return mixed
+	 */
+	public function offsetGet(mixed $offset): mixed {
+		return $this->entity->offsetGet($offset);
+	}
+
+	/**
+	 * @param mixed $offset
+	 * @param mixed $value
+	 * @return void
+	 */
+	public function offsetSet(mixed $offset, mixed $value): void {
+		$this->entity->offsetSet($offset, $value);
+	}
+
+	/**
+	 * @param mixed $offset
+	 * @return void
+	 */
+	public function offsetUnset(mixed $offset): void {
+		$this->entity->offsetUnset($offset);
+	}
+
+	/**
+	 * Proxy property reads to the underlying entity.
+	 *
+	 * @param string $property
+	 * @return mixed
+	 */
+	public function __get(string $property): mixed {
+		return $this->entity->get($property);
+	}
+
+	/**
+	 * Proxy property-existence checks to the underlying entity.
+	 *
+	 * @param string $property
+	 * @return bool
+	 */
+	public function __isset(string $property): bool {
+		return $this->entity->has($property);
+	}
+
+}

--- a/src/Policy/TinyAuthResolver.php
+++ b/src/Policy/TinyAuthResolver.php
@@ -1,0 +1,163 @@
+<?php
+declare(strict_types=1);
+
+namespace TinyAuthBackend\Policy;
+
+use Authorization\Policy\Exception\MissingPolicyException;
+use Authorization\Policy\ResolverInterface;
+use Cake\ORM\Query\SelectQuery;
+use Cake\ORM\Table;
+
+/**
+ * Resolver that returns a single shared `TinyAuthPolicy` instance
+ * for any known resource routed through the Authorization plugin.
+ *
+ * ## Why this exists
+ *
+ * Cake's built-in resolvers are each slightly wrong for the TinyAuth
+ * flow:
+ *
+ * - `MapResolver` matches exact class names, which works for entities
+ *   passed to `$this->Authorization->authorize($article)` but not for
+ *   query objects passed to `$this->Authorization->applyScope($query)`
+ *   — the Authorization plugin unwraps the query to its repository
+ *   (the table) before calling `getPolicy()`, and `MapResolver` won't
+ *   match unless you map the table class too.
+ * - `OrmResolver` does convention-based `App\Policy\FooPolicy` lookup,
+ *   which doesn't let you point at the plugin's `TinyAuthPolicy`
+ *   directly without a thin `src/Policy/` wrapper in every adopting
+ *   app.
+ *
+ * `TinyAuthResolver` short-circuits both: it unwraps `SelectQuery`
+ * resources to their repository (and then to the repository's entity
+ * class), and returns a single cached `TinyAuthPolicy` instance for
+ * every resource it recognizes.
+ *
+ * ## Modes
+ *
+ * The resolver supports two opt-in modes:
+ *
+ * - **Allowlist mode** (default, pass an array of known class names):
+ *   returns the shared policy only for listed classes. Unknown
+ *   resources raise `MissingPolicyException`, which lets a composite
+ *   setup fall through to another resolver.
+ * - **Match-all mode** (pass an empty array or omit `$allowedClasses`):
+ *   returns the shared policy for every resource. Use this when
+ *   every entity in your app should be governed by TinyAuth.
+ *
+ * Both entity classes and table classes can appear in the allowlist —
+ * `Article::class`, `ArticlesTable::class`, or both. Passing a
+ * `SelectQuery` is handled transparently: the resolver unwraps it to
+ * the repository, checks both the table class and the configured
+ * entity class against the allowlist, and uses whichever matches.
+ *
+ * ## Usage
+ *
+ * ```php
+ * // Application::getAuthorizationService()
+ * use TinyAuthBackend\Policy\TinyAuthResolver;
+ *
+ * $resolver = new TinyAuthResolver([
+ *     \App\Model\Entity\Article::class,
+ *     \App\Model\Entity\Project::class,
+ * ]);
+ *
+ * return new \Authorization\AuthorizationService($resolver);
+ * ```
+ *
+ * Or, for apps where every entity should go through TinyAuth:
+ *
+ * ```php
+ * $resolver = new TinyAuthResolver(); // match-all
+ * ```
+ */
+class TinyAuthResolver implements ResolverInterface {
+
+	/**
+	 * @var array<class-string, true>
+	 */
+	protected array $allowedClasses;
+
+	/**
+	 * @var \TinyAuthBackend\Policy\TinyAuthPolicy|null
+	 */
+	protected ?TinyAuthPolicy $policy;
+
+	/**
+	 * @param array<class-string> $allowedClasses Entity or table class names governed by TinyAuth. Empty array = match all.
+	 * @param \TinyAuthBackend\Policy\TinyAuthPolicy|null $policy Optional pre-built policy instance (useful for tests).
+	 */
+	public function __construct(array $allowedClasses = [], ?TinyAuthPolicy $policy = null) {
+		$this->allowedClasses = array_fill_keys($allowedClasses, true);
+		$this->policy = $policy;
+	}
+
+	/**
+	 * @param mixed $resource
+	 * @throws \Authorization\Policy\Exception\MissingPolicyException
+	 * @return object
+	 */
+	public function getPolicy(mixed $resource): object {
+		$classes = $this->resolveCandidateClasses($resource);
+		if ($classes === []) {
+			throw new MissingPolicyException([is_object($resource) ? $resource::class : gettype($resource)]);
+		}
+
+		if (!$this->isAllowed($classes)) {
+			throw new MissingPolicyException($classes);
+		}
+
+		return $this->policy ??= new TinyAuthPolicy();
+	}
+
+	/**
+	 * Extract the candidate class names the allowlist should be
+	 * checked against. Entities and plain objects contribute their
+	 * own class. Tables contribute both their own class and their
+	 * configured entity class. Select queries are unwrapped to their
+	 * repository first and then handled as tables.
+	 *
+	 * @param mixed $resource
+	 * @return array<class-string>
+	 */
+	protected function resolveCandidateClasses(mixed $resource): array {
+		if ($resource instanceof SelectQuery) {
+			$resource = $resource->getRepository();
+		}
+
+		if ($resource instanceof Table) {
+			$classes = [$resource::class];
+			$entityClass = $resource->getEntityClass();
+			if ($entityClass !== $resource::class) {
+				$classes[] = $entityClass;
+			}
+
+			return $classes;
+		}
+
+		if (is_object($resource)) {
+			return [$resource::class];
+		}
+
+		return [];
+	}
+
+	/**
+	 * @param array<class-string> $classes
+	 * @return bool
+	 */
+	protected function isAllowed(array $classes): bool {
+		if ($this->allowedClasses === []) {
+			return true; // Match-all mode.
+		}
+
+		foreach ($classes as $class) {
+			if (isset($this->allowedClasses[$class])) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+}

--- a/tests/TestCase/Identity/EntityIdentityTest.php
+++ b/tests/TestCase/Identity/EntityIdentityTest.php
@@ -1,0 +1,134 @@
+<?php
+declare(strict_types=1);
+
+namespace TinyAuthBackend\Test\TestCase\Identity;
+
+use Authorization\AuthorizationServiceInterface;
+use Authorization\Policy\Result;
+use BadMethodCallException;
+use Cake\ORM\Entity;
+use Cake\TestSuite\TestCase;
+use TinyAuthBackend\Identity\EntityIdentity;
+
+class EntityIdentityTest extends TestCase {
+
+	public function testGetIdentifierReturnsEntityId(): void {
+		$entity = new Entity(['id' => 42, 'name' => 'Alice']);
+		$identity = new EntityIdentity($entity);
+
+		$this->assertSame(42, $identity->getIdentifier());
+	}
+
+	public function testGetIdentifierReturnsNullWhenIdMissing(): void {
+		$entity = new Entity(['name' => 'Alice']);
+		$identity = new EntityIdentity($entity);
+
+		$this->assertNull($identity->getIdentifier());
+	}
+
+	public function testGetOriginalDataReturnsEntity(): void {
+		$entity = new Entity(['id' => 1, 'name' => 'Alice']);
+		$identity = new EntityIdentity($entity);
+
+		$this->assertSame($entity, $identity->getOriginalData());
+	}
+
+	public function testArrayAccessForwardsToEntity(): void {
+		$entity = new Entity(['id' => 1, 'role_id' => 5]);
+		$identity = new EntityIdentity($entity);
+
+		$this->assertTrue(isset($identity['id']));
+		$this->assertSame(5, $identity['role_id']);
+		$this->assertFalse(isset($identity['missing']));
+	}
+
+	public function testArrayAccessWritesAreForwardedToEntity(): void {
+		$entity = new Entity(['id' => 1]);
+		$identity = new EntityIdentity($entity);
+
+		$identity['role_id'] = 7;
+		$this->assertSame(7, $entity->get('role_id'));
+
+		unset($identity['role_id']);
+		$this->assertFalse($entity->has('role_id'));
+	}
+
+	public function testMagicPropertyAccessForwardsToEntity(): void {
+		$entity = new Entity(['id' => 1, 'name' => 'Alice']);
+		$identity = new EntityIdentity($entity);
+
+		$this->assertSame('Alice', $identity->name);
+		$this->assertTrue(isset($identity->name));
+		$this->assertFalse(isset($identity->missing));
+	}
+
+	public function testCanWithoutServiceReturnsFalse(): void {
+		$entity = new Entity(['id' => 1]);
+		$identity = new EntityIdentity($entity);
+
+		$this->assertFalse($identity->can('edit', new Entity()));
+	}
+
+	public function testApplyScopeWithoutServiceReturnsResourceUnchanged(): void {
+		$entity = new Entity(['id' => 1]);
+		$identity = new EntityIdentity($entity);
+
+		$resource = new Entity(['title' => 'hello']);
+		$this->assertSame($resource, $identity->applyScope('index', $resource));
+	}
+
+	public function testCanResultWithoutServiceThrows(): void {
+		$entity = new Entity(['id' => 1]);
+		$identity = new EntityIdentity($entity);
+
+		$this->expectException(BadMethodCallException::class);
+		$this->expectExceptionMessage('requires an AuthorizationService');
+
+		$identity->canResult('edit', new Entity());
+	}
+
+	public function testCanDelegatesToService(): void {
+		$entity = new Entity(['id' => 1]);
+		$resource = new Entity(['id' => 9]);
+
+		$service = $this->createMock(AuthorizationServiceInterface::class);
+		$service->expects($this->once())
+			->method('can')
+			->with($this->isInstanceOf(EntityIdentity::class), 'edit', $resource)
+			->willReturn(true);
+
+		$identity = new EntityIdentity($entity, $service);
+		$this->assertTrue($identity->can('edit', $resource));
+	}
+
+	public function testCanResultDelegatesToService(): void {
+		$entity = new Entity(['id' => 1]);
+		$resource = new Entity(['id' => 9]);
+		$result = new Result(true);
+
+		$service = $this->createMock(AuthorizationServiceInterface::class);
+		$service->expects($this->once())
+			->method('canResult')
+			->with($this->isInstanceOf(EntityIdentity::class), 'edit', $resource)
+			->willReturn($result);
+
+		$identity = new EntityIdentity($entity, $service);
+		$this->assertSame($result, $identity->canResult('edit', $resource));
+	}
+
+	public function testApplyScopeDelegatesToService(): void {
+		$entity = new Entity(['id' => 1]);
+		$resource = new Entity(['scoped' => false]);
+		$scoped = new Entity(['scoped' => true]);
+
+		$service = $this->createMock(AuthorizationServiceInterface::class);
+		$service->expects($this->once())
+			->method('applyScope')
+			->with($this->isInstanceOf(EntityIdentity::class), 'index', $resource)
+			->willReturn($scoped);
+
+		$identity = new EntityIdentity($entity, $service);
+		$this->assertSame($scoped, $identity->applyScope('index', $resource));
+	}
+
+}

--- a/tests/TestCase/Policy/TinyAuthResolverTest.php
+++ b/tests/TestCase/Policy/TinyAuthResolverTest.php
@@ -1,0 +1,122 @@
+<?php
+declare(strict_types=1);
+
+namespace TinyAuthBackend\Test\TestCase\Policy;
+
+use Authorization\Policy\Exception\MissingPolicyException;
+use Cake\ORM\Entity;
+use Cake\ORM\Query\SelectQuery;
+use Cake\ORM\Table;
+use Cake\TestSuite\TestCase;
+use stdClass;
+use TestApp\Model\Entity\Article;
+use TinyAuthBackend\Policy\TinyAuthPolicy;
+use TinyAuthBackend\Policy\TinyAuthResolver;
+
+class TinyAuthResolverTest extends TestCase {
+
+	/**
+	 * Build a SelectQuery test double bound to the given Table without
+	 * touching the database schema layer. We only need `getRepository()`
+	 * to return the table for the resolver to do its unwrapping.
+	 *
+	 * @param \Cake\ORM\Table $table
+	 * @return \Cake\ORM\Query\SelectQuery
+	 */
+	protected function mockSelectQueryOn(Table $table): SelectQuery {
+		$query = $this->createStub(SelectQuery::class);
+		$query->method('getRepository')->willReturn($table);
+
+		return $query;
+	}
+
+	public function testMatchAllModeReturnsPolicyForAnyEntity(): void {
+		$resolver = new TinyAuthResolver();
+
+		$policy = $resolver->getPolicy(new Article());
+		$this->assertInstanceOf(TinyAuthPolicy::class, $policy);
+	}
+
+	public function testMatchAllModeReturnsSharedInstance(): void {
+		$resolver = new TinyAuthResolver();
+
+		$policy1 = $resolver->getPolicy(new Article());
+		$policy2 = $resolver->getPolicy(new Article());
+
+		$this->assertSame($policy1, $policy2);
+	}
+
+	public function testAllowlistModeReturnsPolicyForListedEntity(): void {
+		$resolver = new TinyAuthResolver([Article::class]);
+
+		$policy = $resolver->getPolicy(new Article());
+		$this->assertInstanceOf(TinyAuthPolicy::class, $policy);
+	}
+
+	public function testAllowlistModeThrowsForUnlistedEntity(): void {
+		$resolver = new TinyAuthResolver([Article::class]);
+
+		$this->expectException(MissingPolicyException::class);
+		$resolver->getPolicy(new stdClass());
+	}
+
+	public function testResolvesTableByTableClass(): void {
+		$table = new Table(['alias' => 'Articles']);
+		$resolver = new TinyAuthResolver([$table::class]);
+
+		$policy = $resolver->getPolicy($table);
+		$this->assertInstanceOf(TinyAuthPolicy::class, $policy);
+	}
+
+	public function testResolvesTableByConfiguredEntityClass(): void {
+		$table = new Table(['alias' => 'Articles']);
+		$table->setEntityClass(Article::class);
+
+		$resolver = new TinyAuthResolver([Article::class]);
+		$policy = $resolver->getPolicy($table);
+		$this->assertInstanceOf(TinyAuthPolicy::class, $policy);
+	}
+
+	public function testResolvesSelectQueryByUnwrappingRepository(): void {
+		$table = new Table(['alias' => 'Articles']);
+		$table->setEntityClass(Article::class);
+		$query = $this->mockSelectQueryOn($table);
+
+		$resolver = new TinyAuthResolver([Article::class]);
+		$policy = $resolver->getPolicy($query);
+		$this->assertInstanceOf(TinyAuthPolicy::class, $policy);
+	}
+
+	public function testResolvesSelectQueryInMatchAllMode(): void {
+		$table = new Table(['alias' => 'Articles']);
+		$query = $this->mockSelectQueryOn($table);
+
+		$resolver = new TinyAuthResolver();
+		$policy = $resolver->getPolicy($query);
+		$this->assertInstanceOf(TinyAuthPolicy::class, $policy);
+	}
+
+	public function testThrowsForNonObjectResource(): void {
+		$resolver = new TinyAuthResolver();
+
+		$this->expectException(MissingPolicyException::class);
+		$resolver->getPolicy('string-resource');
+	}
+
+	public function testInjectedPolicyIsReturned(): void {
+		$injected = new TinyAuthPolicy();
+		$resolver = new TinyAuthResolver([], $injected);
+
+		$this->assertSame($injected, $resolver->getPolicy(new Article()));
+	}
+
+	public function testAllowlistRejectsEntityWhenOnlyTableClassListed(): void {
+		$table = new Table(['alias' => 'Articles']);
+		// Only the table class is listed, not the entity class.
+		$resolver = new TinyAuthResolver([$table::class]);
+
+		$this->expectException(MissingPolicyException::class);
+		$resolver->getPolicy(new Entity());
+	}
+
+}


### PR DESCRIPTION
## Summary

Two small, tightly scoped public classes that eliminate ~200 lines of boilerplate every adopting app currently has to write when wiring `TinyAuthPolicy` into `cakephp/authorization`. Found while cleaning up the [cakephp-tinyauth-demo](https://github.com/dereuromark/cakephp-tinyauth-demo) app — both classes existed there as demo-only helpers and are obvious candidates to graduate upstream.

### `TinyAuthResolver` (`src/Policy/TinyAuthResolver.php`)

Policy resolver that returns a shared `TinyAuthPolicy` instance for any known entity, table, or ``SelectQuery``, transparently unwrapping queries to their repository.

- Two modes: **allowlist** (pass an array of class names, unlisted resources raise ``MissingPolicyException``) and **match-all** (empty array, governs every resource).
- Works for both ``\$this->Authorization->authorize(\$entity)`` **and** ``->applyScope(\$query)`` out of the box. Cake's built-in ``MapResolver`` doesn't handle the ``SelectQuery`` unwrapping needed for ``applyScope()``; ``OrmResolver`` forces ``App\Policy\*`` convention classes. This resolver avoids both.
- Both entity and table classes are checked against the allowlist, so you can list either (or both).

### `EntityIdentity` (``src/Identity/EntityIdentity.php``)

Minimal ``Authorization\IdentityInterface`` wrapper around a Cake entity for apps that resolve users without ``cakephp/authentication`` (session payload, JWT claim, upstream SSO gateway).

- Forwards ``ArrayAccess`` and magic property reads to the wrapped entity.
- Accepts an **optional** ``AuthorizationServiceInterface``. When omitted, ``can()`` returns ``false``, ``applyScope()`` is a pass-through, and ``canResult()`` throws — the correct behavior for strategies that gate by role only and never call into the Authorization service.
- Provides ``getIdentifier()`` mirroring ``cakephp/authentication``'s ``Identity`` for a familiar API.

## Tests

- ``tests/TestCase/Identity/EntityIdentityTest.php`` — 12 tests covering the no-service, with-service, ArrayAccess, and magic property paths.
- ``tests/TestCase/Policy/TinyAuthResolverTest.php`` — 11 tests covering match-all mode, allowlist mode, ``SelectQuery`` unwrapping, table-by-entity-class lookup, and failure paths.
- 99/99 existing tests still pass.
- ``composer stan`` and ``composer cs-check`` clean.

## Docs

- ``docs/Authorization.md`` updated: the resolver section now recommends ``TinyAuthResolver`` and explains why it's preferable to ``MapResolver``/``OrmResolver`` for TinyAuth-driven apps. A new "Identity Without ``cakephp/authentication``" section introduces ``EntityIdentity``.

## Deferred

A ``RequestGateMiddleware`` for request-level gating without ``cakephp/authorization`` (the "AdapterOnly rung" story) was also on the table but deferred to a follow-up PR — it needs its own design discussion (trait mixing vs. standalone logic, config surface, unauthorized handler integration) and is substantially larger than the two classes in this PR.

Targeted at ``master`` for inclusion in ``3.0.0``.