### PR TITLE
Add tiny_auth_backend sync CLI command

### DIFF
--- a/src/Command/SyncCommand.php
+++ b/src/Command/SyncCommand.php
@@ -1,0 +1,101 @@
+<?php
+declare(strict_types=1);
+
+namespace TinyAuthBackend\Command;
+
+use Cake\Command\Command;
+use Cake\Console\Arguments;
+use Cake\Console\ConsoleIo;
+use Cake\Console\ConsoleOptionParser;
+use TinyAuthBackend\Service\ControllerSyncService;
+use TinyAuthBackend\Service\ResourceSyncService;
+
+/**
+ * Sync command: scans the application for controllers, actions, and
+ * resource entities, and writes discovered rows into the normalized
+ * TinyAuth tables.
+ *
+ * This is the CLI equivalent of the "Sync" buttons in the admin UI at
+ * `/admin/auth/sync`. It's intended for CI and deploy scripts so
+ * permission state stays aligned with code changes automatically,
+ * without a human having to click through the web UI after every
+ * release.
+ *
+ * Usage:
+ *
+ * ```bash
+ * bin/cake tiny_auth_backend sync # both controllers and resources
+ * bin/cake tiny_auth_backend sync controllers # only controllers + actions
+ * bin/cake tiny_auth_backend sync resources # only entity resources + abilities
+ * ```
+ *
+ * Sync is idempotent — re-running it never clobbers existing grants.
+ * Controllers and actions that appear in code are added; existing
+ * rows are left alone. Orphans (rows whose controllers no longer
+ * exist) are not auto-pruned.
+ */
+class SyncCommand extends Command {
+
+	/**
+	 * @inheritDoc
+	 */
+	public function execute(Arguments $args, ConsoleIo $io): ?int {
+		$type = $args->getArgument('type');
+
+		if (!$type || $type === 'controllers') {
+			$this->syncControllers($io);
+		}
+		if (!$type || $type === 'resources') {
+			$this->syncResources($io);
+		}
+
+		return static::CODE_SUCCESS;
+	}
+
+	/**
+	 * @return \Cake\Console\ConsoleOptionParser
+	 */
+	public function getOptionParser(): ConsoleOptionParser {
+		$parser = parent::getOptionParser();
+		$parser->setDescription(
+			'Sync controllers, actions, and entity resources from code into the TinyAuth backend.',
+		);
+
+		$parser->addArgument('type', [
+			'help' => 'What to sync (controllers/resources). Defaults to both.',
+			'choices' => ['controllers', 'resources'],
+		]);
+
+		return $parser;
+	}
+
+	/**
+	 * @param \Cake\Console\ConsoleIo $io
+	 * @return void
+	 */
+	protected function syncControllers(ConsoleIo $io): void {
+		$result = (new ControllerSyncService())->sync();
+
+		$io->success(sprintf(
+			'Controllers synced: %d added, %d updated, %d actions added',
+			$result['added'],
+			$result['updated'],
+			$result['actions_added'],
+		));
+	}
+
+	/**
+	 * @param \Cake\Console\ConsoleIo $io
+	 * @return void
+	 */
+	protected function syncResources(ConsoleIo $io): void {
+		$result = (new ResourceSyncService())->sync();
+
+		$io->success(sprintf(
+			'Resources synced: %d added, %d abilities added',
+			$result['added'],
+			$result['abilities_added'],
+		));
+	}
+
+}

--- a/src/TinyAuthBackendPlugin.php
+++ b/src/TinyAuthBackendPlugin.php
@@ -9,6 +9,7 @@ use Cake\Core\PluginApplicationInterface;
 use Cake\Routing\RouteBuilder;
 use TinyAuthBackend\Command\ImportCommand;
 use TinyAuthBackend\Command\InitCommand;
+use TinyAuthBackend\Command\SyncCommand;
 
 /**
  * Plugin for TinyAuthBackend
@@ -69,6 +70,7 @@ class TinyAuthBackendPlugin extends BasePlugin {
 	public function console(CommandCollection $commands): CommandCollection {
 		$commands->add('tiny_auth_backend init', InitCommand::class);
 		$commands->add('tiny_auth_backend import', ImportCommand::class);
+		$commands->add('tiny_auth_backend sync', SyncCommand::class);
 
 		return $commands;
 	}

--- a/tests/TestCase/Command/SyncCommandTest.php
+++ b/tests/TestCase/Command/SyncCommandTest.php
@@ -1,0 +1,80 @@
+<?php
+declare(strict_types=1);
+
+namespace TinyAuthBackend\Test\TestCase\Command;
+
+use Cake\Console\TestSuite\ConsoleIntegrationTestTrait;
+use Cake\TestSuite\TestCase;
+use TinyAuthBackend\Test\TestSuite\DatabaseTestTrait;
+
+class SyncCommandTest extends TestCase {
+
+	use ConsoleIntegrationTestTrait;
+	use DatabaseTestTrait;
+
+	protected array $fixtures = [
+		'plugin.TinyAuthBackend.TinyAuthControllers',
+		'plugin.TinyAuthBackend.TinyAuthActions',
+		'plugin.TinyAuthBackend.TinyAuthResources',
+		'plugin.TinyAuthBackend.TinyAuthResourceAbilities',
+	];
+
+	public function setUp(): void {
+		parent::setUp();
+
+		$this->loadPlugins(['TinyAuthBackend']);
+	}
+
+	public function testSyncWithoutArgsRunsBothSubcommands(): void {
+		$this->exec('tiny_auth_backend sync');
+
+		$this->assertExitSuccess();
+		$this->assertOutputContains('Controllers synced:');
+		$this->assertOutputContains('Resources synced:');
+	}
+
+	public function testSyncControllersOnlySkipsResources(): void {
+		$this->exec('tiny_auth_backend sync controllers');
+
+		$this->assertExitSuccess();
+		$this->assertOutputContains('Controllers synced:');
+		$this->assertOutputNotContains('Resources synced:');
+	}
+
+	public function testSyncResourcesOnlySkipsControllers(): void {
+		$this->exec('tiny_auth_backend sync resources');
+
+		$this->assertExitSuccess();
+		$this->assertOutputContains('Resources synced:');
+		$this->assertOutputNotContains('Controllers synced:');
+	}
+
+	public function testSyncRejectsUnknownType(): void {
+		$this->exec('tiny_auth_backend sync garbage');
+
+		$this->assertExitError();
+	}
+
+	public function testSyncIsIdempotent(): void {
+		$this->exec('tiny_auth_backend sync');
+		$this->assertExitSuccess();
+
+		$controllersAfterFirstRun = $this->countRows('tinyauth_controllers', []);
+		$actionsAfterFirstRun = $this->countRows('tinyauth_actions', []);
+
+		$this->exec('tiny_auth_backend sync');
+		$this->assertExitSuccess();
+
+		$this->assertSame(
+			$controllersAfterFirstRun,
+			$this->countRows('tinyauth_controllers', []),
+			'Re-running sync must not create duplicate controller rows.',
+		);
+		$this->assertSame(
+			$actionsAfterFirstRun,
+			$this->countRows('tinyauth_actions', []),
+			'Re-running sync must not create duplicate action rows.',
+		);
+	}
+
+}


### PR DESCRIPTION
## Summary

Ships a CLI wrapper around ``ControllerSyncService`` and ``ResourceSyncService`` so adopters can sync permission state from deploy scripts and CI without clicking through the ``/admin/auth/sync`` web UI after every release.

### Usage

```bash
bin/cake tiny_auth_backend sync              # both controllers and resources
bin/cake tiny_auth_backend sync controllers  # only controllers + actions
bin/cake tiny_auth_backend sync resources    # only entity resources + abilities
```

Follows the same argument-based subcommand pattern as ``ImportCommand`` (``bin/cake tiny_auth_backend import allow``).

### Design

The command is a thin dispatch to the existing sync services — it prints a one-line success message per section with the row counts returned by each service and exits 0 even when nothing new was found, matching the idempotent contract the services already guarantee. No new state is introduced in the plugin; all the scanning/diffing logic lives where it already did.

### Tests

Five ``ConsoleIntegrationTestTrait`` cases in ``tests/TestCase/Command/SyncCommandTest.php``:

- default (no args) runs both subcommands
- ``sync controllers`` skips resources
- ``sync resources`` skips controllers
- ``sync garbage`` is rejected by the argument choices list
- running ``sync`` twice in a row does not create duplicate rows

All 104 tests pass locally, phpstan clean, phpcs clean.

### Motivation

Surfaced while cleaning up the demo app — the demo's Quick Start previously assumed a ``bin/cake tiny_auth_backend sync`` command that never existed, then worked around it with a hack in ``SeedDemoDataCommand`` that called ``ControllerSyncService`` / ``ResourceSyncService`` directly. Shipping the command upstream lets the demo drop that hack in a follow-up, and lets every other adopter skip the hack entirely.

Targeted at ``master`` for inclusion in ``3.0.0``.