### PR TITLE
Make admin UI CSP-compatible (nonce inline scripts, drop inline onclick)

### DIFF
--- a/templates/Admin/Allow/index.php
+++ b/templates/Admin/Allow/index.php
@@ -29,15 +29,19 @@ $this->assign('title', 'Public Actions');
             <div class="flex items-center justify-between mb-3">
                 <h3 class="font-medium"><?= h($controller->full_path) ?></h3>
                 <div class="flex gap-2">
-                    <?= $this->Form->postLink(__('Make All Public'), ['action' => 'bulkToggle'], [
+                    <?= $this->Form->postButton(__('Make All Public'), ['action' => 'bulkToggle'], [
 						'data' => ['controller_id' => $controller->id, 'is_public' => true],
-						'class' => 'text-xs text-blue-600 hover:underline',
-						'block' => true,
+						'class' => 'text-xs text-blue-600 hover:underline bg-transparent border-0 p-0',
+						'form' => [
+							'class' => 'inline',
+						],
 					]) ?>
-                    <?= $this->Form->postLink(__('Make All Protected'), ['action' => 'bulkToggle'], [
+                    <?= $this->Form->postButton(__('Make All Protected'), ['action' => 'bulkToggle'], [
 						'data' => ['controller_id' => $controller->id, 'is_public' => false],
-						'class' => 'text-xs text-blue-600 hover:underline',
-						'block' => true,
+						'class' => 'text-xs text-blue-600 hover:underline bg-transparent border-0 p-0',
+						'form' => [
+							'class' => 'inline',
+						],
 					]) ?>
                 </div>
             </div>

--- a/templates/Admin/Roles/index.php
+++ b/templates/Admin/Roles/index.php
@@ -6,6 +6,7 @@
  * @var array $roles
  */
 $this->assign('title', 'Roles');
+$cspNonce = (string)$this->getRequest()->getAttribute('cspNonce', '');
 ?>
 
 <?php if (!$isManaged) { ?>
@@ -74,10 +75,12 @@ $this->assign('title', 'Roles');
                     <span class="opacity-0 group-hover:opacity-100 flex gap-1">
                         <a href="<?= $this->Url->build(['action' => 'edit', $role->id]) ?>"
                            class="text-blue-600 text-sm">Edit</a>
-                        <?= $this->Form->postLink(__('Delete'), ['action' => 'delete', $role->id], [
-                            'confirm' => __('Delete this role?'),
-                            'class' => 'text-red-600 text-sm',
-                            'block' => true,
+                        <?= $this->Form->postButton(__('Delete'), ['action' => 'delete', $role->id], [
+                            'class' => 'text-red-600 text-sm bg-transparent border-0 p-0',
+                            'form' => [
+                                'class' => 'inline',
+                                'data-confirm-message' => __('Delete this role?'),
+                            ],
                         ]) ?>
                     </span>
                 </div>
@@ -140,7 +143,7 @@ $this->assign('title', 'Roles');
 </div>
 <?php } ?>
 
-<script>
+<script<?= $cspNonce !== '' ? ' nonce="' . h($cspNonce) . '"' : '' ?>>
 function reorderRole(targetId, sourceId) {
     if (targetId === sourceId) return;
 

--- a/templates/Admin/Scopes/index.php
+++ b/templates/Admin/Scopes/index.php
@@ -48,10 +48,12 @@ $this->assign('title', 'Scopes');
                         <div class="flex gap-2">
                             <a href="<?= $this->Url->build(['action' => 'edit', $scope->id]) ?>"
                                class="text-blue-600 text-sm">Edit</a>
-                            <?= $this->Form->postLink(__('Delete'), ['action' => 'delete', $scope->id], [
-                                'confirm' => __('Delete this scope? Permissions using it will be updated.'),
-                                'class' => 'text-red-600 text-sm',
-                                'block' => true,
+                            <?= $this->Form->postButton(__('Delete'), ['action' => 'delete', $scope->id], [
+                                'class' => 'text-red-600 text-sm bg-transparent border-0 p-0',
+                                'form' => [
+                                    'class' => 'inline',
+                                    'data-confirm-message' => __('Delete this scope? Permissions using it will be updated.'),
+                                ],
                             ]) ?>
                         </div>
                     </td>

--- a/templates/layout/tinyauth.php
+++ b/templates/layout/tinyauth.php
@@ -6,6 +6,7 @@ declare(strict_types=1);
  * @var \Cake\View\View $this
  */
 $this->loadHelper('TinyAuthBackend.TinyAuth');
+$cspNonce = (string)$this->getRequest()->getAttribute('cspNonce', '');
 ?>
 <!DOCTYPE html>
 <html lang="en" x-data="{ darkMode: localStorage.getItem('darkMode') === 'true' }" :class="{ 'dark': darkMode }">
@@ -17,7 +18,7 @@ $this->loadHelper('TinyAuthBackend.TinyAuth');
     <script src="https://cdn.tailwindcss.com"></script>
     <script defer src="https://cdn.jsdelivr.net/npm/alpinejs@3.x.x/dist/cdn.min.js"></script>
     <script src="https://unpkg.com/htmx.org@1.9.10"></script>
-    <script>
+    <script<?= $cspNonce !== '' ? ' nonce="' . h($cspNonce) . '"' : '' ?>>
         // Configure HTMX to include CSRF token in all requests
         document.addEventListener('htmx:configRequest', function(event) {
             var csrfToken = document.querySelector('meta[name="csrfToken"]');
@@ -25,8 +26,19 @@ $this->loadHelper('TinyAuthBackend.TinyAuth');
                 event.detail.headers['X-CSRF-Token'] = csrfToken.content;
             }
         });
+
+        // Confirmation dialogs for postButton forms (CSP-safe replacement for postLink + confirm)
+        document.addEventListener('DOMContentLoaded', function() {
+            document.querySelectorAll('form[data-confirm-message]').forEach(function(form) {
+                form.addEventListener('submit', function(e) {
+                    if (!confirm(form.dataset.confirmMessage)) {
+                        e.preventDefault();
+                    }
+                });
+            });
+        });
     </script>
-    <script>
+    <script<?= $cspNonce !== '' ? ' nonce="' . h($cspNonce) . '"' : '' ?>>
         tailwind.config = {
             darkMode: 'class',
             theme: {
@@ -38,7 +50,7 @@ $this->loadHelper('TinyAuthBackend.TinyAuth');
             }
         }
     </script>
-    <script>
+    <script<?= $cspNonce !== '' ? ' nonce="' . h($cspNonce) . '"' : '' ?>>
         window.TinyAuth = {
             urls: {
                 aclToggle: <?= json_encode($this->Url->build(['plugin' => 'TinyAuthBackend', 'controller' => 'Acl', 'action' => 'toggle', 'prefix' => 'Admin'])) ?>,


### PR DESCRIPTION
## Summary

- Add nonce to inline `<script>` blocks in the layout (3) and `Roles/index.php` (1).
- Register the `form[data-confirm-message]` submit delegate in the layout.
- Replace 4 `Form->postLink` + `confirm` calls with `Form->postButton` + `data-confirm-message` across `Roles/index.php`, `Scopes/index.php`, and `Allow/index.php` (2).

## Motivation

Under a strict Content-Security-Policy with `script-src 'self' 'nonce-...'`, inline `<script>` blocks without `nonce` and inline event handlers (`onclick=`, etc.) are blocked by the browser. Per the CSP spec, the `nonce` keyword applies ONLY to inline `<script>` / `<style>` blocks — not to event-handler attributes. `$this->Form->postLink(...)` emits `onclick="document.post_X.submit(); ..."` and is therefore unsafe under strict CSP.

## Changes

- **Layout (`templates/layout/tinyauth.php`)**: add `nonce` to the 3 inline scripts (htmx CSRF config, tailwind config, `window.TinyAuth` URL config). The htmx-config script now also registers the `form[data-confirm-message]` submit delegate so every admin page inherits the confirmation UX.
- **`Admin/Roles/index.php`**: add `nonce` to the inline `reorderRole` script; switch the delete postLink to postButton with `data-confirm-message`.
- **`Admin/Scopes/index.php`**: switch the delete postLink to postButton with `data-confirm-message`.
- **`Admin/Allow/index.php`**: switch the two bulk-toggle postLinks (no confirm) to postButton.

The postButton class includes `bg-transparent border-0 p-0` so the button renders like the original link in the Tailwind-styled UI.

## Alpine.js CDN note

The layout still loads Alpine.js from `https://cdn.jsdelivr.net` (used for the dark-mode toggle via `x-data` / `@click` directives). Apps running under strict CSP need to:

1. Allowlist `https://cdn.jsdelivr.net`, `https://cdn.tailwindcss.com`, and `https://unpkg.com` in `script-src`.
2. Keep `'unsafe-eval'` because the default Alpine build evaluates its directives at runtime.

Switching to the CSP-safe build (`@alpinejs/csp`) is possible but out of scope for this PR — it would require rewriting the inline directives as plugin-provided components.

## Host app nonce setup

Apps that want to benefit need to set a `cspNonce` request attribute in a middleware, e.g.:

```php
$nonce = base64_encode(random_bytes(16));
$request = $request->withAttribute('cspNonce', $nonce);
$response = $response->withHeader(
    'Content-Security-Policy',
    "script-src 'self' 'nonce-{$nonce}' 'unsafe-eval' https://cdn.jsdelivr.net https://cdn.tailwindcss.com https://unpkg.com"
);
```

If no `cspNonce` attribute is present, the `<script>` tag falls back to rendering without `nonce` — apps on permissive CSP continue to work unchanged.

## Before / after

```diff
- <?= $this->Form->postLink(__('Delete'), ['action' => 'delete', $role->id], [
-     'confirm' => __('Delete this role?'),
-     'class' => 'text-red-600 text-sm',
-     'block' => true,
- ]) ?>
+ <?= $this->Form->postButton(__('Delete'), ['action' => 'delete', $role->id], [
+     'class' => 'text-red-600 text-sm bg-transparent border-0 p-0',
+     'form' => [
+         'class' => 'inline',
+         'data-confirm-message' => __('Delete this role?'),
+     ],
+ ]) ?>
```
