### PR TITLE
Remove Alpine.js for strict-CSP compatibility

### DIFF
--- a/src/Controller/Admin/ResourcesController.php
+++ b/src/Controller/Admin/ResourcesController.php
@@ -137,12 +137,13 @@ class ResourcesController extends AppController {
 			}
 		}
 
-		// Return updated cell
+		// Return updated cell — include all scopes so the menu can be re-rendered
 		$scopesTable = $this->fetchTable('TinyAuthBackend.Scopes');
 		$scope = $scopeId ? $scopesTable->find()->where(['id' => $scopeId])->first() : null;
+		$scopes = $scopesTable->find()->orderBy(['name' => 'ASC'])->toArray();
 
 		$this->viewBuilder()->disableAutoLayout();
-		$this->set(compact('abilityId', 'roleId', 'type', 'scope'));
+		$this->set(compact('abilityId', 'roleId', 'type', 'scope', 'scopes'));
 
 		return $this->render('toggle_cell');
 	}

--- a/templates/Admin/Resources/toggle_cell.php
+++ b/templates/Admin/Resources/toggle_cell.php
@@ -5,6 +5,7 @@
  * @var int $roleId
  * @var string $type
  * @var \TinyAuthBackend\Model\Entity\Scope|null $scope
+ * @var array<\TinyAuthBackend\Model\Entity\Scope> $scopes
  * @var string|null $error
  */
 if (isset($error)) { ?>
@@ -26,8 +27,19 @@ if (isset($error)) { ?>
 	?>
 <td id="rcell-<?= $abilityId ?>-<?= $roleId ?>"
 	class="matrix-cell <?= h($class) ?>"
-	x-data="{ showMenu: false }"
-	@click="showMenu = !showMenu">
-	<span><?= h($display) ?></span>
+	data-menu-scope>
+	<div class="relative">
+		<button type="button"
+				class="block w-full text-center"
+				data-menu-toggle
+				aria-haspopup="true">
+			<span><?= h($display) ?></span>
+		</button>
+		<?= $this->element('TinyAuthBackend.resource_matrix_menu', [
+			'abilityId' => $abilityId,
+			'roleId' => $roleId,
+			'scopes' => $scopes,
+		]) ?>
+	</div>
 </td>
 <?php }

--- a/templates/Admin/Roles/index.php
+++ b/templates/Admin/Roles/index.php
@@ -6,7 +6,6 @@
  * @var array $roles
  */
 $this->assign('title', 'Roles');
-$cspNonce = (string)$this->getRequest()->getAttribute('cspNonce', '');
 ?>
 
 <?php if (!$isManaged) { ?>
@@ -55,17 +54,16 @@ $cspNonce = (string)$this->getRequest()->getAttribute('cspNonce', '');
             <a href="<?= $this->Url->build(['action' => 'add']) ?>" class="btn btn-primary">+ Add Role</a>
         </div>
 
-        <div class="p-4" x-data="{ dragging: null }">
+        <div class="p-4" data-role-tree
+             data-reorder-url="<?= $this->Url->build(['action' => 'reorder']) ?>"
+             data-csrf-token="<?= h($this->request->getAttribute('csrfToken')) ?>">
             <?php
             $renderTree = function ($roles, $level = 0) use (&$renderTree) {
                 foreach ($roles as $role) {
             ?>
             <div class="role-item mb-1" style="margin-left: <?= $level * 1.5 ?>rem;"
                  draggable="true"
-                 @dragstart="dragging = <?= $role->id ?>"
-                 @dragend="dragging = null"
-                 @dragover.prevent
-                 @drop="reorderRole(<?= $role->id ?>, dragging)">
+                 data-role-id="<?= $role->id ?>">
                 <div class="flex items-center gap-2 p-2 rounded hover:bg-gray-100 dark:hover:bg-slate-700 group">
                     <span class="cursor-move text-gray-400">&#8942;&#8942;</span>
                     <span class="flex-1">
@@ -143,22 +141,4 @@ $cspNonce = (string)$this->getRequest()->getAttribute('cspNonce', '');
 </div>
 <?php } ?>
 
-<script<?= $cspNonce !== '' ? ' nonce="' . h($cspNonce) . '"' : '' ?>>
-function reorderRole(targetId, sourceId) {
-    if (targetId === sourceId) return;
-
-    fetch('<?= $this->Url->build(['action' => 'reorder']) ?>', {
-        method: 'POST',
-        headers: {
-            'Content-Type': 'application/x-www-form-urlencoded',
-            'X-CSRF-Token': '<?= $this->request->getAttribute('csrfToken') ?>'
-        },
-        body: new URLSearchParams({
-            role_id: sourceId,
-            parent_id: targetId,
-            sort_order: 0
-        })
-    }).then(() => location.reload());
-}
-</script>
 <?php } ?>

--- a/templates/Admin/element/resource_matrix.php
+++ b/templates/Admin/element/resource_matrix.php
@@ -29,7 +29,6 @@
 				$perm = $permissions[$ability->id][$role->id] ?? null;
 				$type = $perm['type'] ?? 'none';
 				$scopeName = $perm['scope_name'] ?? null;
-				$scopeId = $perm['scope_id'] ?? null;
 
 				$display = match ($type) {
 					'allow' => $scopeName ? '●(' . h($scopeName) . ')' : '●',
@@ -41,50 +40,22 @@
 					'deny' => 'text-red-500',
 					default => 'text-gray-400',
 				};
-	?>
+		?>
 			<td id="rcell-<?= $ability->id ?>-<?= $role->id ?>"
 				class="matrix-cell <?= h($class) ?>"
-				x-data="{ showMenu: false }"
-				@click="showMenu = !showMenu">
+				data-menu-scope>
 				<div class="relative">
-					<span><?= h($display) ?></span>
-
-					<!-- Scope selector dropdown -->
-					<div x-show="showMenu" @click.away="showMenu = false"
-						 class="absolute z-10 mt-1 bg-white dark:bg-slate-800 border rounded-md shadow-lg p-2 text-left min-w-[150px]"
-						 style="left: 50%; transform: translateX(-50%);">
-						<div class="text-xs font-medium text-gray-500 mb-1">Permission</div>
-						<button class="block w-full text-left px-2 py-1 rounded hover:bg-gray-100 dark:hover:bg-slate-700 text-sm"
-								hx-post="<?= $this->Url->build(['action' => 'toggle']) ?>"
-								hx-vals='<?= json_encode(['ability_id' => $ability->id, 'role_id' => $role->id, 'type' => 'allow', 'scope_id' => '']) ?>'
-								hx-target="#rcell-<?= $ability->id ?>-<?= $role->id ?>"
-								hx-swap="outerHTML">
-							<span class="text-green-500">●</span> Full access
-						</button>
-						<?php foreach ($scopes as $scope) { ?>
-						<button class="block w-full text-left px-2 py-1 rounded hover:bg-gray-100 dark:hover:bg-slate-700 text-sm"
-								hx-post="<?= $this->Url->build(['action' => 'toggle']) ?>"
-								hx-vals='<?= json_encode(['ability_id' => $ability->id, 'role_id' => $role->id, 'type' => 'allow', 'scope_id' => $scope->id]) ?>'
-								hx-target="#rcell-<?= $ability->id ?>-<?= $role->id ?>"
-								hx-swap="outerHTML">
-							<span class="text-green-500">●</span> <?= h($scope->name) ?>
-						</button>
-						<?php } ?>
-						<button class="block w-full text-left px-2 py-1 rounded hover:bg-gray-100 dark:hover:bg-slate-700 text-sm"
-								hx-post="<?= $this->Url->build(['action' => 'toggle']) ?>"
-								hx-vals='<?= json_encode(['ability_id' => $ability->id, 'role_id' => $role->id, 'type' => 'deny', 'scope_id' => '']) ?>'
-								hx-target="#rcell-<?= $ability->id ?>-<?= $role->id ?>"
-								hx-swap="outerHTML">
-							<span class="text-red-500">✕</span> Deny
-						</button>
-						<button class="block w-full text-left px-2 py-1 rounded hover:bg-gray-100 dark:hover:bg-slate-700 text-sm"
-								hx-post="<?= $this->Url->build(['action' => 'toggle']) ?>"
-								hx-vals='<?= json_encode(['ability_id' => $ability->id, 'role_id' => $role->id, 'type' => 'none', 'scope_id' => '']) ?>'
-								hx-target="#rcell-<?= $ability->id ?>-<?= $role->id ?>"
-								hx-swap="outerHTML">
-							<span class="text-gray-400">○</span> Remove
-						</button>
-					</div>
+					<button type="button"
+							class="block w-full text-center"
+							data-menu-toggle
+							aria-haspopup="true">
+						<span><?= h($display) ?></span>
+					</button>
+					<?= $this->element('TinyAuthBackend.resource_matrix_menu', [
+						'abilityId' => $ability->id,
+						'roleId' => $role->id,
+						'scopes' => $scopes,
+					]) ?>
 				</div>
 			</td>
 			<?php } ?>

--- a/templates/Admin/element/resource_matrix_menu.php
+++ b/templates/Admin/element/resource_matrix_menu.php
@@ -1,0 +1,51 @@
+<?php
+/**
+ * Scope-selector menu rendered inside a resource-matrix cell. Shared between
+ * the initial matrix render and the HTMX-swap fragment so the cell stays
+ * fully functional after a swap.
+ *
+ * @var \Cake\View\View $this
+ * @var int $abilityId
+ * @var int $roleId
+ * @var array<\TinyAuthBackend\Model\Entity\Scope> $scopes
+ */
+?>
+<div data-menu
+	 class="menu-popover absolute z-10 mt-1 bg-white dark:bg-slate-800 border rounded-md shadow-lg p-2 text-left min-w-[150px]"
+	 style="left: 50%; transform: translateX(-50%);">
+	<div class="text-xs font-medium text-gray-500 mb-1"><?= __('Permission') ?></div>
+	<button type="button"
+			class="block w-full text-left px-2 py-1 rounded hover:bg-gray-100 dark:hover:bg-slate-700 text-sm"
+			hx-post="<?= $this->Url->build(['action' => 'toggle']) ?>"
+			hx-vals='<?= json_encode(['ability_id' => $abilityId, 'role_id' => $roleId, 'type' => 'allow', 'scope_id' => '']) ?>'
+			hx-target="#rcell-<?= $abilityId ?>-<?= $roleId ?>"
+			hx-swap="outerHTML">
+		<span class="text-green-500">●</span> <?= __('Full access') ?>
+	</button>
+	<?php foreach ($scopes as $scope) { ?>
+	<button type="button"
+			class="block w-full text-left px-2 py-1 rounded hover:bg-gray-100 dark:hover:bg-slate-700 text-sm"
+			hx-post="<?= $this->Url->build(['action' => 'toggle']) ?>"
+			hx-vals='<?= json_encode(['ability_id' => $abilityId, 'role_id' => $roleId, 'type' => 'allow', 'scope_id' => $scope->id]) ?>'
+			hx-target="#rcell-<?= $abilityId ?>-<?= $roleId ?>"
+			hx-swap="outerHTML">
+		<span class="text-green-500">●</span> <?= h($scope->name) ?>
+	</button>
+	<?php } ?>
+	<button type="button"
+			class="block w-full text-left px-2 py-1 rounded hover:bg-gray-100 dark:hover:bg-slate-700 text-sm"
+			hx-post="<?= $this->Url->build(['action' => 'toggle']) ?>"
+			hx-vals='<?= json_encode(['ability_id' => $abilityId, 'role_id' => $roleId, 'type' => 'deny', 'scope_id' => '']) ?>'
+			hx-target="#rcell-<?= $abilityId ?>-<?= $roleId ?>"
+			hx-swap="outerHTML">
+		<span class="text-red-500">✕</span> <?= __('Deny') ?>
+	</button>
+	<button type="button"
+			class="block w-full text-left px-2 py-1 rounded hover:bg-gray-100 dark:hover:bg-slate-700 text-sm"
+			hx-post="<?= $this->Url->build(['action' => 'toggle']) ?>"
+			hx-vals='<?= json_encode(['ability_id' => $abilityId, 'role_id' => $roleId, 'type' => 'none', 'scope_id' => '']) ?>'
+			hx-target="#rcell-<?= $abilityId ?>-<?= $roleId ?>"
+			hx-swap="outerHTML">
+		<span class="text-gray-400">○</span> <?= __('Remove') ?>
+	</button>
+</div>

--- a/templates/Admin/element/tree.php
+++ b/templates/Admin/element/tree.php
@@ -24,46 +24,43 @@ if ($selectedId !== null) {
 		}
 	}
 }
-$expandedJson = json_encode((object)$expandedNodes);
 ?>
-<div x-data="{ expanded: <?= h($expandedJson) ?> }">
-    <?php foreach ($tree as $plugin => $pluginData) { ?>
-    <div class="mb-2">
-        <div class="tree-item flex items-center gap-1 cursor-pointer"
-             @click="expanded['<?= h($plugin) ?>'] = !expanded['<?= h($plugin) ?>']">
-            <span x-text="expanded['<?= h($plugin) ?>'] ? '&#9660;' : '&#9654;'" class="text-xs text-gray-400"></span>
-            <span class="font-medium"><?= h($plugin) ?></span>
-        </div>
+<div class="tree">
+	<?php foreach ($tree as $plugin => $pluginData) { ?>
+	<details class="tree-node mb-2"<?= isset($expandedNodes[$plugin]) ? ' open' : '' ?>>
+		<summary class="tree-item flex items-center gap-1 cursor-pointer">
+			<span class="tree-marker text-xs text-gray-400" aria-hidden="true"></span>
+			<span class="font-medium"><?= h($plugin) ?></span>
+		</summary>
 
-        <div x-show="expanded['<?= h($plugin) ?>']" x-collapse class="ml-4">
-            <?php foreach ($pluginData['prefixes'] as $prefix => $prefixData) { ?>
+		<div class="ml-4">
+			<?php foreach ($pluginData['prefixes'] as $prefix => $prefixData) { ?>
 				<?php if ($prefix !== '_root') { ?>
-            <div class="mb-1">
-                <div class="tree-item flex items-center gap-1 text-sm cursor-pointer"
-                     @click="expanded['<?= h($plugin) ?>_<?= h($prefix) ?>'] = !expanded['<?= h($plugin) ?>_<?= h($prefix) ?>']">
-                    <span x-text="expanded['<?= h($plugin) ?>_<?= h($prefix) ?>'] ? '&#9660;' : '&#9654;'" class="text-xs text-gray-400"></span>
-                    <span><?= h($prefix) ?>/</span>
-                </div>
-
-                <div x-show="expanded['<?= h($plugin) ?>_<?= h($prefix) ?>']" x-collapse class="ml-4">
-                    <?php foreach ($prefixData['controllers'] as $controller) { ?>
-                    <a href="<?= $this->Url->build(['action' => 'index', '?' => ['controller_id' => $controller->id]]) ?>"
-                       class="tree-item block text-sm <?= (int)$controller->id === $selectedId ? 'active' : '' ?>">
-                        <?= h($controller->name) ?>
-                    </a>
-                    <?php } ?>
-                </div>
-            </div>
-                <?php } else { ?>
+					<?php $key = $plugin . '_' . $prefix; ?>
+			<details class="tree-node mb-1"<?= isset($expandedNodes[$key]) ? ' open' : '' ?>>
+				<summary class="tree-item flex items-center gap-1 text-sm cursor-pointer">
+					<span class="tree-marker text-xs text-gray-400" aria-hidden="true"></span>
+					<span><?= h($prefix) ?>/</span>
+				</summary>
+				<div class="ml-4">
 					<?php foreach ($prefixData['controllers'] as $controller) { ?>
-                <a href="<?= $this->Url->build(['action' => 'index', '?' => ['controller_id' => $controller->id]]) ?>"
-                   class="tree-item block text-sm <?= (int)$controller->id === $selectedId ? 'active' : '' ?>">
+					<a href="<?= $this->Url->build(['action' => 'index', '?' => ['controller_id' => $controller->id]]) ?>"
+					   class="tree-item block text-sm <?= (int)$controller->id === $selectedId ? 'active' : '' ?>">
 						<?= h($controller->name) ?>
-                </a>
-                    <?php } ?>
-                <?php } ?>
-            <?php } ?>
-        </div>
-    </div>
-    <?php } ?>
+					</a>
+					<?php } ?>
+				</div>
+			</details>
+				<?php } else { ?>
+					<?php foreach ($prefixData['controllers'] as $controller) { ?>
+				<a href="<?= $this->Url->build(['action' => 'index', '?' => ['controller_id' => $controller->id]]) ?>"
+				   class="tree-item block text-sm <?= (int)$controller->id === $selectedId ? 'active' : '' ?>">
+						<?= h($controller->name) ?>
+				</a>
+					<?php } ?>
+				<?php } ?>
+			<?php } ?>
+		</div>
+	</details>
+	<?php } ?>
 </div>

--- a/templates/layout/tinyauth.php
+++ b/templates/layout/tinyauth.php
@@ -9,15 +9,21 @@ $this->loadHelper('TinyAuthBackend.TinyAuth');
 $cspNonce = (string)$this->getRequest()->getAttribute('cspNonce', '');
 ?>
 <!DOCTYPE html>
-<html lang="en" x-data="{ darkMode: localStorage.getItem('darkMode') === 'true' }" :class="{ 'dark': darkMode }">
+<html lang="en">
 <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <?= $this->Html->meta('csrfToken', $this->request->getAttribute('csrfToken')) ?>
     <title><?= $this->fetch('title') ?> - TinyAuth</title>
     <script src="https://cdn.tailwindcss.com"></script>
-    <script defer src="https://cdn.jsdelivr.net/npm/alpinejs@3.x.x/dist/cdn.min.js"></script>
     <script src="https://unpkg.com/htmx.org@1.9.10"></script>
+    <script<?= $cspNonce !== '' ? ' nonce="' . h($cspNonce) . '"' : '' ?>>
+        // FOUC-safe dark-mode bootstrap (runs before paint)
+        (function () {
+            var dark = localStorage.getItem('darkMode') === 'true';
+            document.documentElement.classList.toggle('dark', dark);
+        })();
+    </script>
     <script<?= $cspNonce !== '' ? ' nonce="' . h($cspNonce) . '"' : '' ?>>
         // Configure HTMX to include CSRF token in all requests
         document.addEventListener('htmx:configRequest', function(event) {
@@ -101,12 +107,12 @@ $cspNonce = (string)$this->getRequest()->getAttribute('cspNonce', '');
                     <?php } ?>
 
                     <!-- Theme toggle -->
-                    <button @click="darkMode = !darkMode; localStorage.setItem('darkMode', darkMode)"
+                    <button data-action="toggle-dark-mode"
                             class="ml-2 p-2 rounded-md hover:bg-gray-100 dark:hover:bg-slate-700"
-                            :aria-label="darkMode ? '<?= __('Switch to light mode') ?>' : '<?= __('Switch to dark mode') ?>'"
+                            aria-label="<?= __('Toggle dark mode') ?>"
                             type="button">
-                        <span x-show="!darkMode">🌙</span>
-                        <span x-show="darkMode">☀️</span>
+                        <span data-dark-mode-icon="light">🌙</span>
+                        <span data-dark-mode-icon="dark" hidden>☀️</span>
                     </button>
                 </nav>
             </div>

--- a/tests/TestCase/CspComplianceTest.php
+++ b/tests/TestCase/CspComplianceTest.php
@@ -1,0 +1,70 @@
+<?php
+declare(strict_types=1);
+
+namespace TinyAuthBackend\Test\TestCase;
+
+use Cake\TestSuite\TestCase;
+use RecursiveDirectoryIterator;
+use RecursiveIteratorIterator;
+
+/**
+ * Guard against re-introducing Alpine.js or other unsafe-eval / unsafe-inline
+ * patterns in plugin templates. Strict CSP forbids these.
+ */
+class CspComplianceTest extends TestCase {
+
+	/**
+	 * Alpine.js attributes — they require the Function() evaluator, blocked by strict CSP.
+     * @var string
+	 */
+	private const ALPINE_PATTERN = '/(\sx-(data|show|if|for|init|cloak|text|html|bind|on|model|collapse)\b'
+		. '|\s@(click|change|submit|keydown|keyup|dragstart|dragend|dragover|drop|input|focus|blur)\b'
+		. '|\s:(class|aria-label|aria-expanded|disabled|value|style)\s*=)/';
+
+	/**
+	 * Inline event handlers — onclick=, onchange=, etc. blocked by strict CSP.
+     * @var string
+	 */
+	private const INLINE_HANDLER_PATTERN = '/\son(click|change|submit|load|keyup|keydown|mouseover|mouseout|focus|blur|input)\s*=/';
+
+	/**
+	 * @return void
+	 */
+	public function testNoAlpineDirectivesInTemplates(): void {
+		$offenders = $this->scanTemplates(static::ALPINE_PATTERN);
+		$this->assertSame([], $offenders, "Alpine directives found:\n" . implode("\n", $offenders));
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testNoInlineEventHandlersInTemplates(): void {
+		$offenders = $this->scanTemplates(static::INLINE_HANDLER_PATTERN);
+		$this->assertSame([], $offenders, "Inline event handlers found:\n" . implode("\n", $offenders));
+	}
+
+	/**
+	 * @param string $pattern
+	 * @return array<string>
+	 */
+	private function scanTemplates(string $pattern): array {
+		$root = dirname(__DIR__, 2) . '/templates';
+		$iterator = new RecursiveIteratorIterator(new RecursiveDirectoryIterator($root));
+		$offenders = [];
+		foreach ($iterator as $file) {
+			if (!$file->isFile() || !str_ends_with((string)$file, '.php')) {
+				continue;
+			}
+			$content = (string)file_get_contents((string)$file);
+			$lines = preg_split('/\R/', $content) ?: [];
+			foreach ($lines as $idx => $line) {
+				if (preg_match($pattern, $line)) {
+					$offenders[] = sprintf('%s:%d: %s', (string)$file, $idx + 1, trim($line));
+				}
+			}
+		}
+
+		return $offenders;
+	}
+
+}

--- a/webroot/css/tinyauth.css
+++ b/webroot/css/tinyauth.css
@@ -144,3 +144,31 @@
     color: rgb(156 163 175);
     background-color: rgb(30 41 59);
 }
+
+/* Dropdown menu: hidden by default, visible when toggled open */
+[data-menu] {
+    display: none;
+}
+
+[data-menu].is-open {
+    display: block;
+}
+
+/* Tree: hide native disclosure marker, show our own caret */
+.tree details > summary {
+    list-style: none;
+}
+
+.tree details > summary::-webkit-details-marker {
+    display: none;
+}
+
+.tree details > summary .tree-marker::before {
+    content: "\25B6"; /* ▶ */
+    display: inline-block;
+    transition: transform 0.1s ease;
+}
+
+.tree details[open] > summary .tree-marker::before {
+    transform: rotate(90deg);
+}

--- a/webroot/js/tinyauth.js
+++ b/webroot/js/tinyauth.js
@@ -25,7 +25,122 @@ document.addEventListener('DOMContentLoaded', function() {
             document.querySelector('input[name="q"]')?.focus();
         }
     });
+
+    // Dark-mode toggle (data-action="toggle-dark-mode" button)
+    document.addEventListener('click', function(event) {
+        var btn = event.target.closest('[data-action="toggle-dark-mode"]');
+        if (!btn) {
+            return;
+        }
+        var nowDark = !document.documentElement.classList.contains('dark');
+        document.documentElement.classList.toggle('dark', nowDark);
+        localStorage.setItem('darkMode', nowDark ? 'true' : 'false');
+        document.querySelectorAll('[data-dark-mode-icon]').forEach(function(el) {
+            el.hidden = el.dataset.darkModeIcon !== (nowDark ? 'dark' : 'light');
+        });
+    });
+
+    // Sync dark-mode icon visibility on initial load (FOUC bootstrap set the class already)
+    var initialDark = document.documentElement.classList.contains('dark');
+    document.querySelectorAll('[data-dark-mode-icon]').forEach(function(el) {
+        el.hidden = el.dataset.darkModeIcon !== (initialDark ? 'dark' : 'light');
+    });
 });
+
+// Generic dropdown menu: click [data-menu-toggle] toggles its scope's [data-menu].
+// Click outside or Escape closes any open menu. Survives HTMX swaps via document delegation.
+(function() {
+    function closeAllMenus(except) {
+        document.querySelectorAll('[data-menu].is-open').forEach(function(m) {
+            if (m !== except) {
+                m.classList.remove('is-open');
+            }
+        });
+    }
+
+    document.addEventListener('click', function(event) {
+        var toggle = event.target.closest('[data-menu-toggle]');
+        if (toggle) {
+            event.stopPropagation();
+            var scope = toggle.closest('[data-menu-scope]') || toggle;
+            var menu = scope.querySelector('[data-menu]');
+            if (menu) {
+                var willOpen = !menu.classList.contains('is-open');
+                closeAllMenus(menu);
+                menu.classList.toggle('is-open', willOpen);
+            }
+            return;
+        }
+
+        if (event.target.closest('[data-menu].is-open')) {
+            return;
+        }
+        closeAllMenus(null);
+    });
+
+    document.addEventListener('keydown', function(event) {
+        if (event.key === 'Escape') {
+            closeAllMenus(null);
+        }
+    });
+})();
+
+// Role hierarchy drag-and-drop reorder (replaces Alpine @dragstart/@dragend/@drop bindings)
+(function() {
+    var draggingId = null;
+
+    document.addEventListener('dragstart', function(event) {
+        var item = event.target.closest('[data-role-id]');
+        if (!item || !item.closest('[data-role-tree]')) {
+            return;
+        }
+        draggingId = item.dataset.roleId;
+        if (event.dataTransfer) {
+            event.dataTransfer.effectAllowed = 'move';
+        }
+    });
+
+    document.addEventListener('dragend', function() {
+        draggingId = null;
+    });
+
+    document.addEventListener('dragover', function(event) {
+        var item = event.target.closest('[data-role-id]');
+        if (!item || !item.closest('[data-role-tree]')) {
+            return;
+        }
+        event.preventDefault();
+    });
+
+    document.addEventListener('drop', function(event) {
+        var item = event.target.closest('[data-role-id]');
+        var tree = item && item.closest('[data-role-tree]');
+        if (!item || !tree || draggingId === null) {
+            return;
+        }
+        event.preventDefault();
+
+        var targetId = item.dataset.roleId;
+        if (targetId === draggingId) {
+            return;
+        }
+
+        fetch(tree.dataset.reorderUrl, {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/x-www-form-urlencoded',
+                'X-CSRF-Token': tree.dataset.csrfToken,
+            },
+            body: new URLSearchParams({
+                role_id: draggingId,
+                parent_id: targetId,
+                sort_order: '0',
+            }),
+        }).then(function() {
+            window.location.reload();
+        });
+    });
+})();
 
 // Namespace for TinyAuth functions
 window.TinyAuth = window.TinyAuth || {};


### PR DESCRIPTION
## Summary

Drops the Alpine.js CDN dependency so the admin UI runs under a strict CSP (no `unsafe-eval`). HTMX (already in the layout) keeps handling all server mutations; Alpine's role as a client-state glue is replaced with three patterns:

1. **Native semantic HTML** (`<details>`/`<summary>`) for the controller tree — zero JS, full keyboard accessibility, expanded state preserved via the `open` attribute.
2. **Data-attribute + event delegation** in `webroot/js/tinyauth.js` for the dark-mode toggle and the resource-matrix scope-selector dropdowns. Click-outside and Escape close menus. Survives HTMX swaps because delegation runs on `document`.
3. **Native HTML5 drag-and-drop** with vanilla `dragstart` / `dragend` / `dragover` / `drop` listeners for the role-hierarchy reorder. The inline `reorderRole()` `<script>` block moves into `tinyauth.js`.

## Critical detail: HTMX swap functionality preserved

After clicking a resource-matrix cell action (Allow/Deny/Remove/scope), HTMX swaps the cell with `Admin/Resources/toggle_cell.php`. The previous template returned only the new state without the popover, which would have left the cell un-clickable until a full reload.

This PR extracts the popover into a shared element `Admin/element/resource_matrix_menu.php` used by **both** `resource_matrix.php` (initial render) and `toggle_cell.php` (swap fragment), and `ResourcesController::toggle()` now passes `$scopes` to the swap so the menu re-renders. **Full functionality is preserved post-swap.**

## Layout changes

- Drop `<script defer src=".../alpinejs@3.x.x..."></script>`
- Drop `x-data` / `:class` on `<html>`; replace with FOUC-safe nonced bootstrap script that toggles `.dark` from localStorage before paint
- Theme button: `data-action="toggle-dark-mode"` + `data-dark-mode-icon` spans hidden via the `[hidden]` attribute

## Guard test

`tests/TestCase/CspComplianceTest.php` scans `templates/` for Alpine directives (`x-data`, `x-show`, `@click`, `:class=`, etc.) and inline event handlers (`onclick=`, etc.) — fails if any reappear. Two assertions, currently green.

## Verification

- `composer test` — 109 tests pass (107 baseline + 2 CSP guards)
- `composer stan` — clean
- `composer cs-check` — clean

Browser smoke test by maintainer recommended (the plugin is not currently composer-required by the toolbox app, so the test_app or an `app_local`-pinned dev install is the easiest path).

## Out of scope (next strict-CSP step)

The Tailwind CDN runtime (`https://cdn.tailwindcss.com`) compiles classes in the browser via `Function()`, which still requires `script-src 'unsafe-eval'`. Replacing it with a pre-compiled `webroot/css/tailwind.css` is a separate follow-up.

A few non-Alpine inline `style="..."` attributes survive (`margin-left: <?= \$level * 1.5 ?>rem` in Roles/index, the popover positioning `style="left: 50%; transform: translateX(-50%)"` in the matrix). They still need `style-src 'unsafe-inline'`. Also follow-up.