### PR TITLE
Skip role prune when external source is empty (data-loss fix)

### DIFF
--- a/src/Service/RoleSourceService.php
+++ b/src/Service/RoleSourceService.php
@@ -241,17 +241,26 @@ class RoleSourceService {
 	/**
 	 * Remove shadow rows for roles that no longer exist in the external source.
 	 *
+	 * An empty external set is treated as "skip prune this request" rather than
+	 * "prune everything": a misconfigured/transiently-failing source (callable
+	 * that throws and is swallowed upstream, Configure path that doesn't resolve
+	 * yet during bootstrap, ...) would otherwise wipe the entire `tinyauth_roles`
+	 * table on every GET, cascade-destroying every permission row that references
+	 * a role. Operators that genuinely want to clear all shadow rows can do so
+	 * via the table directly; we refuse to do it implicitly from a read path.
+	 *
 	 * @param \TinyAuthBackend\Model\Table\RolesTable $rolesTable
 	 * @param array<string, int> $roles
 	 * @return void
 	 */
 	protected function pruneExternalRoles(Table $rolesTable, array $roles): void {
 		$expectedAliases = array_keys($roles);
-
-		$staleRoles = $rolesTable->find();
-		if ($expectedAliases) {
-			$staleRoles->where(['alias NOT IN' => $expectedAliases]);
+		if (!$expectedAliases) {
+			return;
 		}
+
+		$staleRoles = $rolesTable->find()
+			->where(['alias NOT IN' => $expectedAliases]);
 
 		/** @var \TinyAuthBackend\Model\Entity\Role $staleRole */
 		foreach ($staleRoles->all() as $staleRole) {

--- a/tests/TestCase/Service/RoleSourceServiceTest.php
+++ b/tests/TestCase/Service/RoleSourceServiceTest.php
@@ -115,7 +115,11 @@ class RoleSourceServiceTest extends TestCase {
 		}
 	}
 
-	public function testExternalRoleSourcePrunesAllShadowRowsWhenSourceIsEmpty(): void {
+	public function testEmptyExternalRoleSourceDoesNotPruneShadowRows(): void {
+		// Regression: a misconfigured / transiently-empty external source must
+		// not wipe `tinyauth_roles` on every GET. Empty set means "skip prune",
+		// not "prune all" — otherwise every permission row that FKs a role is
+		// cascade-destroyed.
 		$this->insertRow('tinyauth_roles', [
 			'id' => 10,
 			'name' => 'Editor',
@@ -123,13 +127,21 @@ class RoleSourceServiceTest extends TestCase {
 			'parent_id' => null,
 			'sort_order' => 1,
 		]);
+		$this->insertRow('tinyauth_roles', [
+			'id' => 20,
+			'name' => 'Manager',
+			'alias' => 'manager',
+			'parent_id' => null,
+			'sort_order' => 2,
+		]);
 		Configure::write('TinyAuthBackend.roleSource', []);
 		(new RoleSourceService())->clearCache();
 
 		$roles = (new RoleSourceService())->getRoles();
 
 		$this->assertSame([], $roles);
-		$this->assertSame(0, $this->countRows('tinyauth_roles', ['id' => 10]));
+		$this->assertSame(1, $this->countRows('tinyauth_roles', ['id' => 10]));
+		$this->assertSame(1, $this->countRows('tinyauth_roles', ['id' => 20]));
 	}
 
 }


### PR DESCRIPTION
## Summary

`RoleSourceService::pruneExternalRoles()` previously skipped only the `alias NOT IN` WHERE clause when the expected-aliases list was empty, then proceeded to `delete()` every row returned by the unfiltered `find()`. Combined with `syncExternalRoles()` being invoked from every `getRoles()` call (admin index pages, dashboard stats), a transiently-empty external source — a callable that swallows an exception and returns `[]`, a Configure path that doesn't resolve yet during bootstrap, an upstream service hiccup — would wipe every row in `tinyauth_roles` on each GET, cascade-destroying the permission rows that FK them.

The new behavior treats an empty external set as "skip prune this request" rather than "prune all". Operators that genuinely want to clear shadow rows can do so via the table directly; the read path refuses to do it implicitly.

## Changes

- `src/Service/RoleSourceService.php:248-271` — early return from `pruneExternalRoles()` when `$expectedAliases` is empty; rationale documented inline.
- `tests/TestCase/Service/RoleSourceServiceTest.php:118-145` — replace the prior test that asserted the unsafe "prune all" behavior with a regression test that seeds two shadow rows, configures an empty external source, and asserts both rows survive.

Verified: full phpunit suite (118 tests, 349 assertions) passes; phpstan clean; phpcs clean.