### PR TITLE
Use plugin-specific i18n domain for translations

### DIFF
--- a/resources/locales/tinyauth_backend.pot
+++ b/resources/locales/tinyauth_backend.pot
@@ -1,0 +1,169 @@
+# LANGUAGE translation of CakePHP Application
+# Copyright YEAR NAME <EMAIL@ADDRESS>
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PROJECT VERSION\n"
+"POT-Creation-Date: 2026-05-04 02:29+0200\n"
+"PO-Revision-Date: YYYY-mm-DD HH:MM+ZZZZ\n"
+"Last-Translator: NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <EMAIL@ADDRESS>\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=INTEGER; plural=EXPRESSION;\n"
+
+msgid "Invalid controller."
+msgstr ""
+
+msgid "Actions updated."
+msgstr ""
+
+msgid "TinyAuthBackend admin backend is not configured. Set TinyAuthBackend.adminAccess to a Closure that returns true for permitted callers."
+msgstr ""
+
+msgid "Ability name is required."
+msgstr ""
+
+msgid "Ability \"{0}\" already exists for this resource."
+msgstr ""
+
+msgid "Ability added."
+msgstr ""
+
+msgid "Could not add ability."
+msgstr ""
+
+msgid "Cannot delete ability. It has {0} permission(s) assigned."
+msgstr ""
+
+msgid "Ability deleted."
+msgstr ""
+
+msgid "Could not delete ability."
+msgstr ""
+
+msgid "Roles are managed externally and cannot be created here."
+msgstr ""
+
+msgid "Role saved."
+msgstr ""
+
+msgid "Could not save role."
+msgstr ""
+
+msgid "Roles are managed externally and cannot be edited here."
+msgstr ""
+
+msgid "Role updated."
+msgstr ""
+
+msgid "Could not update role."
+msgstr ""
+
+msgid "Roles are managed externally and cannot be deleted here."
+msgstr ""
+
+msgid "Cannot delete role. It has {0} child role(s)."
+msgstr ""
+
+msgid "Cannot delete role. It has {0} ACL permission(s)."
+msgstr ""
+
+msgid "Cannot delete role. It has {0} resource permission(s)."
+msgstr ""
+
+msgid "Role deleted."
+msgstr ""
+
+msgid "Could not delete role."
+msgstr ""
+
+msgid "Scope saved."
+msgstr ""
+
+msgid "Could not save scope."
+msgstr ""
+
+msgid "Scope updated."
+msgstr ""
+
+msgid "Could not update scope."
+msgstr ""
+
+msgid "Cannot delete scope. It is used by {0} resource permission(s)."
+msgstr ""
+
+msgid "Scope deleted."
+msgstr ""
+
+msgid "Could not delete scope."
+msgstr ""
+
+msgid "Sync complete: {0} controllers added, {1} actions added."
+msgstr ""
+
+msgid "Sync complete: {0} resources added, {1} abilities added."
+msgstr ""
+
+msgid "Allow"
+msgstr ""
+
+msgid "Deny"
+msgstr ""
+
+msgid "This ability name already exists for this resource."
+msgstr ""
+
+msgid "This alias is already in use."
+msgstr ""
+
+msgid "A role cannot be its own parent."
+msgstr ""
+
+msgid "Parent role does not exist."
+msgstr ""
+
+msgid "Circular parent reference detected."
+msgstr ""
+
+msgid "Invalid field name. Use only letters, numbers, and underscores."
+msgstr ""
+
+msgid "Make All Public"
+msgstr ""
+
+msgid "Make All Protected"
+msgstr ""
+
+msgid "+ Add Ability"
+msgstr ""
+
+msgid "Save"
+msgstr ""
+
+msgid "Delete"
+msgstr ""
+
+msgid "Delete this role?"
+msgstr ""
+
+msgid "Delete this scope? Permissions using it will be updated."
+msgstr ""
+
+msgid "Sync Now"
+msgstr ""
+
+msgid "Permission"
+msgstr ""
+
+msgid "Full access"
+msgstr ""
+
+msgid "Remove"
+msgstr ""
+
+msgid "Toggle dark mode"
+msgstr ""
+

--- a/src/Controller/Admin/AllowController.php
+++ b/src/Controller/Admin/AllowController.php
@@ -86,7 +86,7 @@ class AllowController extends AppController {
 		$isPublic = filter_var($this->request->getData('is_public'), FILTER_VALIDATE_BOOLEAN);
 
 		if (!$controllerId) {
-			$this->Flash->error(__('Invalid controller.'));
+			$this->Flash->error(__d('tinyauth_backend', 'Invalid controller.'));
 
 			return $this->redirect(['action' => 'index']);
 		}
@@ -99,7 +99,7 @@ class AllowController extends AppController {
 
 		CacheInvalidator::clearAllow();
 
-		$this->Flash->success(__('Actions updated.'));
+		$this->Flash->success(__d('tinyauth_backend', 'Actions updated.'));
 
 		return $this->redirect(['action' => 'index']);
 	}

--- a/src/Controller/Admin/ResourcesController.php
+++ b/src/Controller/Admin/ResourcesController.php
@@ -158,7 +158,7 @@ class ResourcesController extends AppController {
 		$name = trim((string)$this->request->getData('name'));
 
 		if ($name === '') {
-			$this->Flash->error(__('Ability name is required.'));
+			$this->Flash->error(__d('tinyauth_backend', 'Ability name is required.'));
 
 			return $this->redirect(['action' => 'index', '?' => ['resource_id' => $resourceId]]);
 		}
@@ -168,7 +168,7 @@ class ResourcesController extends AppController {
 		// Check for duplicate
 		$exists = $abilitiesTable->exists(['resource_id' => $resourceId, 'name' => $name]);
 		if ($exists) {
-			$this->Flash->error(__('Ability "{0}" already exists for this resource.', $name));
+			$this->Flash->error(__d('tinyauth_backend', 'Ability "{0}" already exists for this resource.', $name));
 
 			return $this->redirect(['action' => 'index', '?' => ['resource_id' => $resourceId]]);
 		}
@@ -179,9 +179,9 @@ class ResourcesController extends AppController {
 		]);
 
 		if ($abilitiesTable->save($ability)) {
-			$this->Flash->success(__('Ability added.'));
+			$this->Flash->success(__d('tinyauth_backend', 'Ability added.'));
 		} else {
-			$this->Flash->error(__('Could not add ability.'));
+			$this->Flash->error(__d('tinyauth_backend', 'Could not add ability.'));
 		}
 
 		return $this->redirect(['action' => 'index', '?' => ['resource_id' => $resourceId]]);
@@ -203,15 +203,15 @@ class ResourcesController extends AppController {
 		$aclTable = $this->fetchTable('TinyAuthBackend.ResourceAcl');
 		$usageCount = $aclTable->find()->where(['resource_ability_id' => $id])->count();
 		if ($usageCount > 0) {
-			$this->Flash->error(__('Cannot delete ability. It has {0} permission(s) assigned.', $usageCount));
+			$this->Flash->error(__d('tinyauth_backend', 'Cannot delete ability. It has {0} permission(s) assigned.', $usageCount));
 
 			return $this->redirect(['action' => 'index', '?' => ['resource_id' => $resourceId]]);
 		}
 
 		if ($abilitiesTable->delete($ability)) {
-			$this->Flash->success(__('Ability deleted.'));
+			$this->Flash->success(__d('tinyauth_backend', 'Ability deleted.'));
 		} else {
-			$this->Flash->error(__('Could not delete ability.'));
+			$this->Flash->error(__d('tinyauth_backend', 'Could not delete ability.'));
 		}
 
 		return $this->redirect(['action' => 'index', '?' => ['resource_id' => $resourceId]]);

--- a/src/Controller/Admin/RolesController.php
+++ b/src/Controller/Admin/RolesController.php
@@ -41,7 +41,7 @@ class RolesController extends AppController {
 	 */
 	public function add(): ?Response {
 		if (!$this->roleSource->isManaged()) {
-			$this->Flash->error(__('Roles are managed externally and cannot be created here.'));
+			$this->Flash->error(__d('tinyauth_backend', 'Roles are managed externally and cannot be created here.'));
 
 			return $this->redirect(['action' => 'index']);
 		}
@@ -53,11 +53,11 @@ class RolesController extends AppController {
 			$role = $rolesTable->patchEntity($role, $this->request->getData());
 			if ($rolesTable->save($role)) {
 				$this->roleSource->clearCache();
-				$this->Flash->success(__('Role saved.'));
+				$this->Flash->success(__d('tinyauth_backend', 'Role saved.'));
 
 				return $this->redirect(['action' => 'index']);
 			}
-			$this->Flash->error(__('Could not save role.'));
+			$this->Flash->error(__d('tinyauth_backend', 'Could not save role.'));
 		}
 
 		$parents = $rolesTable->find('list', keyField: 'id', valueField: 'name')
@@ -75,7 +75,7 @@ class RolesController extends AppController {
 	 */
 	public function edit(int $id): ?Response {
 		if (!$this->roleSource->isManaged()) {
-			$this->Flash->error(__('Roles are managed externally and cannot be edited here.'));
+			$this->Flash->error(__d('tinyauth_backend', 'Roles are managed externally and cannot be edited here.'));
 
 			return $this->redirect(['action' => 'index']);
 		}
@@ -88,11 +88,11 @@ class RolesController extends AppController {
 			$role = $rolesTable->patchEntity($role, $data);
 			if ($rolesTable->save($role)) {
 				$this->roleSource->clearCache();
-				$this->Flash->success(__('Role updated.'));
+				$this->Flash->success(__d('tinyauth_backend', 'Role updated.'));
 
 				return $this->redirect(['action' => 'index']);
 			}
-			$this->Flash->error(__('Could not update role.'));
+			$this->Flash->error(__d('tinyauth_backend', 'Could not update role.'));
 		}
 
 		// Exclude self from parent options to prevent self-reference
@@ -114,7 +114,7 @@ class RolesController extends AppController {
 		$this->request->allowMethod(['post', 'delete']);
 
 		if (!$this->roleSource->isManaged()) {
-			$this->Flash->error(__('Roles are managed externally and cannot be deleted here.'));
+			$this->Flash->error(__d('tinyauth_backend', 'Roles are managed externally and cannot be deleted here.'));
 
 			return $this->redirect(['action' => 'index']);
 		}
@@ -125,7 +125,7 @@ class RolesController extends AppController {
 		// Check for child roles
 		$childCount = $rolesTable->find()->where(['parent_id' => $id])->count();
 		if ($childCount > 0) {
-			$this->Flash->error(__('Cannot delete role. It has {0} child role(s).', $childCount));
+			$this->Flash->error(__d('tinyauth_backend', 'Cannot delete role. It has {0} child role(s).', $childCount));
 
 			return $this->redirect(['action' => 'index']);
 		}
@@ -134,7 +134,7 @@ class RolesController extends AppController {
 		$aclTable = $this->fetchTable('TinyAuthBackend.AclPermissions');
 		$aclCount = $aclTable->find()->where(['role_id' => $id])->count();
 		if ($aclCount > 0) {
-			$this->Flash->error(__('Cannot delete role. It has {0} ACL permission(s).', $aclCount));
+			$this->Flash->error(__d('tinyauth_backend', 'Cannot delete role. It has {0} ACL permission(s).', $aclCount));
 
 			return $this->redirect(['action' => 'index']);
 		}
@@ -143,16 +143,16 @@ class RolesController extends AppController {
 		$resourceAclTable = $this->fetchTable('TinyAuthBackend.ResourceAcl');
 		$resourceCount = $resourceAclTable->find()->where(['role_id' => $id])->count();
 		if ($resourceCount > 0) {
-			$this->Flash->error(__('Cannot delete role. It has {0} resource permission(s).', $resourceCount));
+			$this->Flash->error(__d('tinyauth_backend', 'Cannot delete role. It has {0} resource permission(s).', $resourceCount));
 
 			return $this->redirect(['action' => 'index']);
 		}
 
 		if ($rolesTable->delete($role)) {
 			$this->roleSource->clearCache();
-			$this->Flash->success(__('Role deleted.'));
+			$this->Flash->success(__d('tinyauth_backend', 'Role deleted.'));
 		} else {
-			$this->Flash->error(__('Could not delete role.'));
+			$this->Flash->error(__d('tinyauth_backend', 'Could not delete role.'));
 		}
 
 		return $this->redirect(['action' => 'index']);

--- a/src/Controller/Admin/ScopesController.php
+++ b/src/Controller/Admin/ScopesController.php
@@ -30,11 +30,11 @@ class ScopesController extends AppController {
 		if ($this->request->is('post')) {
 			$scope = $scopesTable->patchEntity($scope, $this->request->getData());
 			if ($scopesTable->save($scope)) {
-				$this->Flash->success(__('Scope saved.'));
+				$this->Flash->success(__d('tinyauth_backend', 'Scope saved.'));
 
 				return $this->redirect(['action' => 'index']);
 			}
-			$this->Flash->error(__('Could not save scope.'));
+			$this->Flash->error(__d('tinyauth_backend', 'Could not save scope.'));
 		}
 
 		$this->set(compact('scope'));
@@ -53,11 +53,11 @@ class ScopesController extends AppController {
 		if ($this->request->is(['post', 'put', 'patch'])) {
 			$scope = $scopesTable->patchEntity($scope, $this->request->getData());
 			if ($scopesTable->save($scope)) {
-				$this->Flash->success(__('Scope updated.'));
+				$this->Flash->success(__d('tinyauth_backend', 'Scope updated.'));
 
 				return $this->redirect(['action' => 'index']);
 			}
-			$this->Flash->error(__('Could not update scope.'));
+			$this->Flash->error(__d('tinyauth_backend', 'Could not update scope.'));
 		}
 
 		$this->set(compact('scope'));
@@ -79,15 +79,15 @@ class ScopesController extends AppController {
 		$resourceAclTable = $this->fetchTable('TinyAuthBackend.ResourceAcl');
 		$usageCount = $resourceAclTable->find()->where(['scope_id' => $id])->count();
 		if ($usageCount > 0) {
-			$this->Flash->error(__('Cannot delete scope. It is used by {0} resource permission(s).', $usageCount));
+			$this->Flash->error(__d('tinyauth_backend', 'Cannot delete scope. It is used by {0} resource permission(s).', $usageCount));
 
 			return $this->redirect(['action' => 'index']);
 		}
 
 		if ($scopesTable->delete($scope)) {
-			$this->Flash->success(__('Scope deleted.'));
+			$this->Flash->success(__d('tinyauth_backend', 'Scope deleted.'));
 		} else {
-			$this->Flash->error(__('Could not delete scope.'));
+			$this->Flash->error(__d('tinyauth_backend', 'Could not delete scope.'));
 		}
 
 		return $this->redirect(['action' => 'index']);

--- a/src/Controller/Admin/SyncController.php
+++ b/src/Controller/Admin/SyncController.php
@@ -21,7 +21,8 @@ class SyncController extends AppController {
 				'addActions' => (bool)$this->request->getData('add_actions', true),
 			]);
 
-			$this->Flash->success(__(
+			$this->Flash->success(__d(
+				'tinyauth_backend',
 				'Sync complete: {0} controllers added, {1} actions added.',
 				$result['added'],
 				$result['actions_added'],
@@ -70,7 +71,8 @@ class SyncController extends AppController {
 				'addDefaultAbilities' => (bool)$this->request->getData('add_abilities', true),
 			]);
 
-			$this->Flash->success(__(
+			$this->Flash->success(__d(
+				'tinyauth_backend',
 				'Sync complete: {0} resources added, {1} abilities added.',
 				$result['added'],
 				$result['abilities_added'],

--- a/src/Model/Entity/AclPermission.php
+++ b/src/Model/Entity/AclPermission.php
@@ -47,8 +47,8 @@ class AclPermission extends Entity {
 	 */
 	public static function types(): array {
 		return [
-			static::TYPE_ALLOW => __('Allow'),
-			static::TYPE_DENY => __('Deny'),
+			static::TYPE_ALLOW => __d('tinyauth_backend', 'Allow'),
+			static::TYPE_DENY => __d('tinyauth_backend', 'Deny'),
 		];
 	}
 

--- a/src/Model/Entity/ResourceAcl.php
+++ b/src/Model/Entity/ResourceAcl.php
@@ -49,8 +49,8 @@ class ResourceAcl extends Entity {
 	 */
 	public static function types(): array {
 		return [
-			static::TYPE_ALLOW => __('Allow'),
-			static::TYPE_DENY => __('Deny'),
+			static::TYPE_ALLOW => __d('tinyauth_backend', 'Allow'),
+			static::TYPE_DENY => __d('tinyauth_backend', 'Deny'),
 		];
 	}
 

--- a/src/Model/Table/ResourceAbilitiesTable.php
+++ b/src/Model/Table/ResourceAbilitiesTable.php
@@ -79,7 +79,7 @@ class ResourceAbilitiesTable extends Table {
 
 					return !$this->exists($conditions);
 				},
-				'message' => __('This ability name already exists for this resource.'),
+				'message' => __d('tinyauth_backend', 'This ability name already exists for this resource.'),
 			]);
 
 		$validator

--- a/src/Model/Table/RolesTable.php
+++ b/src/Model/Table/RolesTable.php
@@ -109,7 +109,7 @@ class RolesTable extends Table {
 			->add('alias', 'unique', [
 				'rule' => 'validateUnique',
 				'provider' => 'table',
-				'message' => __('This alias is already in use.'),
+				'message' => __d('tinyauth_backend', 'This alias is already in use.'),
 			]);
 
 		$validator
@@ -127,7 +127,7 @@ class RolesTable extends Table {
 
 					return true;
 				},
-				'message' => __('A role cannot be its own parent.'),
+				'message' => __d('tinyauth_backend', 'A role cannot be its own parent.'),
 			])
 			->add('parent_id', 'exists', [
 				'rule' => function ($value, $context) {
@@ -137,7 +137,7 @@ class RolesTable extends Table {
 
 					return $this->exists(['id' => $value]);
 				},
-				'message' => __('Parent role does not exist.'),
+				'message' => __d('tinyauth_backend', 'Parent role does not exist.'),
 			])
 			->add('parent_id', 'noCircular', [
 				'rule' => function ($value, $context) {
@@ -162,7 +162,7 @@ class RolesTable extends Table {
 
 					return true;
 				},
-				'message' => __('Circular parent reference detected.'),
+				'message' => __d('tinyauth_backend', 'Circular parent reference detected.'),
 			]);
 
 		$validator

--- a/src/Model/Table/ScopesTable.php
+++ b/src/Model/Table/ScopesTable.php
@@ -59,7 +59,7 @@ class ScopesTable extends Table {
 			->notEmptyString('entity_field')
 			->add('entity_field', 'validFieldName', [
 				'rule' => ['custom', '/^[a-zA-Z_][a-zA-Z0-9_]*$/'],
-				'message' => __('Invalid field name. Use only letters, numbers, and underscores.'),
+				'message' => __d('tinyauth_backend', 'Invalid field name. Use only letters, numbers, and underscores.'),
 			]);
 
 		$validator
@@ -69,7 +69,7 @@ class ScopesTable extends Table {
 			->notEmptyString('user_field')
 			->add('user_field', 'validFieldName', [
 				'rule' => ['custom', '/^[a-zA-Z_][a-zA-Z0-9_]*$/'],
-				'message' => __('Invalid field name. Use only letters, numbers, and underscores.'),
+				'message' => __d('tinyauth_backend', 'Invalid field name. Use only letters, numbers, and underscores.'),
 			]);
 
 		return $validator;

--- a/templates/Admin/Allow/index.php
+++ b/templates/Admin/Allow/index.php
@@ -29,14 +29,14 @@ $this->assign('title', 'Public Actions');
             <div class="flex items-center justify-between mb-3">
                 <h3 class="font-medium"><?= h($controller->full_path) ?></h3>
                 <div class="flex gap-2">
-                    <?= $this->Form->postButton(__('Make All Public'), ['action' => 'bulkToggle'], [
+                    <?= $this->Form->postButton(__d('tinyauth_backend', 'Make All Public'), ['action' => 'bulkToggle'], [
 						'data' => ['controller_id' => $controller->id, 'is_public' => true],
 						'class' => 'text-xs text-blue-600 hover:underline bg-transparent border-0 p-0',
 						'form' => [
 							'class' => 'inline',
 						],
 					]) ?>
-                    <?= $this->Form->postButton(__('Make All Protected'), ['action' => 'bulkToggle'], [
+                    <?= $this->Form->postButton(__d('tinyauth_backend', 'Make All Protected'), ['action' => 'bulkToggle'], [
 						'data' => ['controller_id' => $controller->id, 'is_public' => false],
 						'class' => 'text-xs text-blue-600 hover:underline bg-transparent border-0 p-0',
 						'form' => [

--- a/templates/Admin/Resources/index.php
+++ b/templates/Admin/Resources/index.php
@@ -63,7 +63,7 @@ $this->assign('title', 'Resource Permissions');
 						'class' => 'form-input flex-1',
 						'placeholder' => 'New ability name (e.g., publish, archive)',
 					]) ?>
-					<?= $this->Form->button(__('+ Add Ability'), ['class' => 'btn btn-secondary']) ?>
+					<?= $this->Form->button(__d('tinyauth_backend', '+ Add Ability'), ['class' => 'btn btn-secondary']) ?>
 				</div>
 				<?= $this->Form->end() ?>
 			</div>

--- a/templates/Admin/Roles/form.php
+++ b/templates/Admin/Roles/form.php
@@ -52,7 +52,7 @@ $this->assign('title', $isEdit ? 'Edit Role' : 'Add Role');
             </div>
 
             <div class="flex gap-3 pt-4">
-                <?= $this->Form->button(__('Save'), ['class' => 'btn btn-primary']) ?>
+                <?= $this->Form->button(__d('tinyauth_backend', 'Save'), ['class' => 'btn btn-primary']) ?>
                 <a href="<?= $this->Url->build(['action' => 'index']) ?>" class="btn btn-secondary">Cancel</a>
             </div>
 

--- a/templates/Admin/Roles/index.php
+++ b/templates/Admin/Roles/index.php
@@ -74,11 +74,11 @@ $this->assign('title', 'Roles');
                     <span class="opacity-0 group-hover:opacity-100 flex gap-1">
                         <a href="<?= $this->Url->build(['action' => 'edit', $role->id]) ?>"
                            class="text-blue-600 text-sm">Edit</a>
-                        <?= $this->Form->postButton(__('Delete'), ['action' => 'delete', $role->id], [
+                        <?= $this->Form->postButton(__d('tinyauth_backend', 'Delete'), ['action' => 'delete', $role->id], [
                             'class' => 'text-red-600 text-sm bg-transparent border-0 p-0',
                             'form' => [
                                 'class' => 'inline',
-                                'data-confirm-message' => __('Delete this role?'),
+                                'data-confirm-message' => __d('tinyauth_backend', 'Delete this role?'),
                             ],
                         ]) ?>
                     </span>

--- a/templates/Admin/Scopes/form.php
+++ b/templates/Admin/Scopes/form.php
@@ -60,7 +60,7 @@ $this->assign('title', $isEdit ? 'Edit Scope' : 'Add Scope');
             </div>
 
             <div class="flex gap-3 pt-4">
-                <?= $this->Form->button(__('Save'), ['class' => 'btn btn-primary']) ?>
+                <?= $this->Form->button(__d('tinyauth_backend', 'Save'), ['class' => 'btn btn-primary']) ?>
                 <a href="<?= $this->Url->build(['action' => 'index']) ?>" class="btn btn-secondary">Cancel</a>
             </div>
 

--- a/templates/Admin/Scopes/index.php
+++ b/templates/Admin/Scopes/index.php
@@ -48,11 +48,11 @@ $this->assign('title', 'Scopes');
                         <div class="flex gap-2">
                             <a href="<?= $this->Url->build(['action' => 'edit', $scope->id]) ?>"
                                class="text-blue-600 text-sm">Edit</a>
-                            <?= $this->Form->postButton(__('Delete'), ['action' => 'delete', $scope->id], [
+                            <?= $this->Form->postButton(__d('tinyauth_backend', 'Delete'), ['action' => 'delete', $scope->id], [
                                 'class' => 'text-red-600 text-sm bg-transparent border-0 p-0',
                                 'form' => [
                                     'class' => 'inline',
-                                    'data-confirm-message' => __('Delete this scope? Permissions using it will be updated.'),
+                                    'data-confirm-message' => __d('tinyauth_backend', 'Delete this scope? Permissions using it will be updated.'),
                                 ],
                             ]) ?>
                         </div>

--- a/templates/Admin/Sync/controllers.php
+++ b/templates/Admin/Sync/controllers.php
@@ -63,7 +63,7 @@ $newCount = count(array_filter($diff, fn ($d) => $d['status'] === 'new'));
                 </label>
             </div>
             <div class="flex gap-2">
-                <?= $this->Form->button(__('Sync Now'), ['class' => 'btn btn-primary']) ?>
+                <?= $this->Form->button(__d('tinyauth_backend', 'Sync Now'), ['class' => 'btn btn-primary']) ?>
                 <a href="<?= $this->Url->build(['controller' => 'Acl', 'action' => 'index']) ?>"
                    class="btn btn-secondary">Cancel</a>
             </div>

--- a/templates/Admin/Sync/resources.php
+++ b/templates/Admin/Sync/resources.php
@@ -56,7 +56,7 @@ $newCount = count(array_filter($diff, fn ($d) => $d['status'] === 'new'));
                 </label>
             </div>
             <div class="flex gap-2">
-                <?= $this->Form->button(__('Sync Now'), ['class' => 'btn btn-primary']) ?>
+                <?= $this->Form->button(__d('tinyauth_backend', 'Sync Now'), ['class' => 'btn btn-primary']) ?>
                 <a href="<?= $this->Url->build(['controller' => 'Resources', 'action' => 'index']) ?>"
                    class="btn btn-secondary">Cancel</a>
             </div>

--- a/templates/Admin/element/resource_matrix_menu.php
+++ b/templates/Admin/element/resource_matrix_menu.php
@@ -12,14 +12,14 @@
 ?>
 <div data-menu
 	 class="menu-popover menu-popover-centered absolute z-10 mt-1 bg-white dark:bg-slate-800 border rounded-md shadow-lg p-2 text-left min-w-[150px]">
-	<div class="text-xs font-medium text-gray-500 mb-1"><?= __('Permission') ?></div>
+	<div class="text-xs font-medium text-gray-500 mb-1"><?= __d('tinyauth_backend', 'Permission') ?></div>
 	<button type="button"
 			class="block w-full text-left px-2 py-1 rounded hover:bg-gray-100 dark:hover:bg-slate-700 text-sm"
 			hx-post="<?= $this->Url->build(['action' => 'toggle']) ?>"
 			hx-vals='<?= json_encode(['ability_id' => $abilityId, 'role_id' => $roleId, 'type' => 'allow', 'scope_id' => '']) ?>'
 			hx-target="#rcell-<?= $abilityId ?>-<?= $roleId ?>"
 			hx-swap="outerHTML">
-		<span class="text-green-500">●</span> <?= __('Full access') ?>
+		<span class="text-green-500">●</span> <?= __d('tinyauth_backend', 'Full access') ?>
 	</button>
 	<?php foreach ($scopes as $scope) { ?>
 	<button type="button"
@@ -37,7 +37,7 @@
 			hx-vals='<?= json_encode(['ability_id' => $abilityId, 'role_id' => $roleId, 'type' => 'deny', 'scope_id' => '']) ?>'
 			hx-target="#rcell-<?= $abilityId ?>-<?= $roleId ?>"
 			hx-swap="outerHTML">
-		<span class="text-red-500">✕</span> <?= __('Deny') ?>
+		<span class="text-red-500">✕</span> <?= __d('tinyauth_backend', 'Deny') ?>
 	</button>
 	<button type="button"
 			class="block w-full text-left px-2 py-1 rounded hover:bg-gray-100 dark:hover:bg-slate-700 text-sm"
@@ -45,6 +45,6 @@
 			hx-vals='<?= json_encode(['ability_id' => $abilityId, 'role_id' => $roleId, 'type' => 'none', 'scope_id' => '']) ?>'
 			hx-target="#rcell-<?= $abilityId ?>-<?= $roleId ?>"
 			hx-swap="outerHTML">
-		<span class="text-gray-400">○</span> <?= __('Remove') ?>
+		<span class="text-gray-400">○</span> <?= __d('tinyauth_backend', 'Remove') ?>
 	</button>
 </div>

--- a/templates/layout/tinyauth.php
+++ b/templates/layout/tinyauth.php
@@ -98,7 +98,7 @@ $cspNonce = (string)$this->getRequest()->getAttribute('cspNonce', '');
                     <!-- Theme toggle -->
                     <button data-action="toggle-dark-mode"
                             class="ml-2 p-2 rounded-md hover:bg-gray-100 dark:hover:bg-slate-700"
-                            aria-label="<?= __('Toggle dark mode') ?>"
+                            aria-label="<?= __d('tinyauth_backend', 'Toggle dark mode') ?>"
                             type="button">
                         <span data-dark-mode-icon="light">🌙</span>
                         <span data-dark-mode-icon="dark" hidden>☀️</span>


### PR DESCRIPTION
## Summary

- Convert 57 `__()` calls across `src/` and `templates/` to `__d('tinyauth_backend', ...)` so plugin strings live in their own domain.
- Add `resources/locales/tinyauth_backend.pot` (51 unique msgids) so language packs can be derived from a stable POT.

## Why

Plugin strings were landing in the host app's `default` domain. Anyone translating the host app would have ended up translating this plugin's UI under their own domain — and shipping a translated language pack with the plugin was effectively impossible.

## Verification (local)

- phpunit: 118 / 118
- phpstan: no errors
- phpcs: clean