### PR TITLE
Fix two perf bugs: read-side role sync, hierarchy/sync N+1

### DIFF
--- a/src/Controller/Admin/AclController.php
+++ b/src/Controller/Admin/AclController.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 namespace TinyAuthBackend\Controller\Admin;
 
 use Cake\Core\Configure;
-use Cake\Datasource\EntityInterface;
 use Cake\Http\Exception\BadRequestException;
 use Cake\Http\Response;
 use TinyAuthBackend\Service\HierarchyService;
@@ -124,32 +123,26 @@ class AclController extends AppController {
 			$controllersTable = $this->fetchTable('TinyAuthBackend.TinyauthControllers');
 			$actionsTable = $this->fetchTable('TinyAuthBackend.Actions');
 
-			// Filter in PHP instead of via SQL LIKE so that user-supplied
-			// `_` / `%` match literally and not as LIKE wildcards. The
-			// admin matrix tables are bounded (one row per controller /
-			// action of the host app) so a full scan is cheap and avoids
-			// per-database ESCAPE clause quirks.
-			$needle = mb_strtolower($q);
-			$match = function (EntityInterface|array $row) use ($needle): bool {
-				$name = $row instanceof EntityInterface ? $row->get('name') : ($row['name'] ?? '');
+			// Server-side case-insensitive LIKE with explicit ESCAPE so user-supplied
+			// `_` / `%` / backslash are matched literally, not as wildcards. The previous
+			// implementation pulled the full controllers + actions tables into PHP per
+			// keystroke, which is an OOM hazard once the host app has many controllers.
+			$pattern = '%' . $this->escapeLikeNeedle(mb_strtolower($q)) . '%';
 
-				return str_contains(mb_strtolower((string)$name), $needle);
-			};
+			$results['controllers'] = $controllersTable->find()
+				->where("LOWER(TinyauthControllers.name) LIKE :pattern ESCAPE '\\'")
+				->bind(':pattern', $pattern, 'string')
+				->limit(5)
+				->all()
+				->toArray();
 
-			$results['controllers'] = array_slice(
-				array_values(array_filter($controllersTable->find()->all()->toArray(), $match)),
-				0,
-				5,
-			);
-
-			$results['actions'] = array_slice(
-				array_values(array_filter(
-					$actionsTable->find()->contain(['TinyauthControllers'])->all()->toArray(),
-					$match,
-				)),
-				0,
-				5,
-			);
+			$results['actions'] = $actionsTable->find()
+				->contain(['TinyauthControllers'])
+				->where("LOWER(Actions.name) LIKE :pattern ESCAPE '\\'")
+				->bind(':pattern', $pattern, 'string')
+				->limit(5)
+				->all()
+				->toArray();
 
 			$roles = (new RoleSourceService())->getRoleEntities();
 			$results['roles'] = array_slice(array_values(array_filter($roles, function (object $role) use ($q): bool {
@@ -161,6 +154,20 @@ class AclController extends AppController {
 		}
 
 		$this->set('results', $results);
+	}
+
+	/**
+	 * Backslash-escape `\`, `%`, `_` in a search needle so it can be safely interpolated
+	 * between `%…%` wildcards in a SQL LIKE clause that uses `ESCAPE '\\'`.
+	 *
+	 * Order matters: the backslash itself must be escaped first, otherwise the next
+	 * passes would double-escape any backslashes they introduce.
+	 *
+	 * @param string $needle
+	 * @return string
+	 */
+	protected function escapeLikeNeedle(string $needle): string {
+		return str_replace(['\\', '%', '_'], ['\\\\', '\\%', '\\_'], $needle);
 	}
 
 	/**

--- a/src/Controller/Admin/AclController.php
+++ b/src/Controller/Admin/AclController.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 namespace TinyAuthBackend\Controller\Admin;
 
 use Cake\Core\Configure;
+use Cake\Datasource\EntityInterface;
 use Cake\Http\Exception\BadRequestException;
 use Cake\Http\Response;
 use TinyAuthBackend\Service\HierarchyService;
@@ -123,33 +124,32 @@ class AclController extends AppController {
 			$controllersTable = $this->fetchTable('TinyAuthBackend.TinyauthControllers');
 			$actionsTable = $this->fetchTable('TinyAuthBackend.Actions');
 
-			// Server-side case-insensitive LIKE with explicit ESCAPE so user-supplied
-			// `_` / `%` are matched literally, not as wildcards. The previous
-			// implementation pulled the full controllers + actions tables into PHP per
-			// keystroke, which is an OOM hazard once the host app has many controllers.
-			//
-			// `!` is used as the escape character (not `\\`) because the backslash is
-			// driver-dependent inside SQL string literals: MySQL treats `'\\'` as a
-			// 2-char escape sequence, while SQLite and Postgres (with the default
-			// standard_conforming_strings = on) treat it as a literal two-character
-			// string. Picking a printable ASCII char that is never an escape lets the
-			// same SQL travel cleanly across MySQL, Postgres, and SQLite.
-			$pattern = '%' . $this->escapeLikeNeedle(mb_strtolower($q)) . '%';
+			// Filter in PHP instead of via SQL LIKE so that user-supplied
+			// `_` / `%` match literally and not as LIKE wildcards. The
+			// admin matrix tables are bounded (one row per controller /
+			// action of the host app) so a full scan is cheap and avoids
+			// per-database ESCAPE clause quirks.
+			$needle = mb_strtolower($q);
+			$match = function (EntityInterface|array $row) use ($needle): bool {
+				$name = $row instanceof EntityInterface ? $row->get('name') : ($row['name'] ?? '');
 
-			$results['controllers'] = $controllersTable->find()
-				->where("LOWER(TinyauthControllers.name) LIKE :pattern ESCAPE '!'")
-				->bind(':pattern', $pattern, 'string')
-				->limit(5)
-				->all()
-				->toArray();
+				return str_contains(mb_strtolower((string)$name), $needle);
+			};
 
-			$results['actions'] = $actionsTable->find()
-				->contain(['TinyauthControllers'])
-				->where("LOWER(Actions.name) LIKE :pattern ESCAPE '!'")
-				->bind(':pattern', $pattern, 'string')
-				->limit(5)
-				->all()
-				->toArray();
+			$results['controllers'] = array_slice(
+				array_values(array_filter($controllersTable->find()->all()->toArray(), $match)),
+				0,
+				5,
+			);
+
+			$results['actions'] = array_slice(
+				array_values(array_filter(
+					$actionsTable->find()->contain(['TinyauthControllers'])->all()->toArray(),
+					$match,
+				)),
+				0,
+				5,
+			);
 
 			$roles = (new RoleSourceService())->getRoleEntities();
 			$results['roles'] = array_slice(array_values(array_filter($roles, function (object $role) use ($q): bool {
@@ -161,20 +161,6 @@ class AclController extends AppController {
 		}
 
 		$this->set('results', $results);
-	}
-
-	/**
-	 * Prefix-escape `!`, `%`, `_` in a search needle so it can be safely interpolated
-	 * between `%…%` wildcards in a SQL LIKE clause that uses `ESCAPE '!'`.
-	 *
-	 * Order matters: the escape character itself must be escaped first, otherwise the
-	 * later passes would double-escape any `!` they introduce.
-	 *
-	 * @param string $needle
-	 * @return string
-	 */
-	protected function escapeLikeNeedle(string $needle): string {
-		return str_replace(['!', '%', '_'], ['!!', '!%', '!_'], $needle);
 	}
 
 	/**

--- a/src/Controller/Admin/AclController.php
+++ b/src/Controller/Admin/AclController.php
@@ -124,13 +124,20 @@ class AclController extends AppController {
 			$actionsTable = $this->fetchTable('TinyAuthBackend.Actions');
 
 			// Server-side case-insensitive LIKE with explicit ESCAPE so user-supplied
-			// `_` / `%` / backslash are matched literally, not as wildcards. The previous
+			// `_` / `%` are matched literally, not as wildcards. The previous
 			// implementation pulled the full controllers + actions tables into PHP per
 			// keystroke, which is an OOM hazard once the host app has many controllers.
+			//
+			// `!` is used as the escape character (not `\\`) because the backslash is
+			// driver-dependent inside SQL string literals: MySQL treats `'\\'` as a
+			// 2-char escape sequence, while SQLite and Postgres (with the default
+			// standard_conforming_strings = on) treat it as a literal two-character
+			// string. Picking a printable ASCII char that is never an escape lets the
+			// same SQL travel cleanly across MySQL, Postgres, and SQLite.
 			$pattern = '%' . $this->escapeLikeNeedle(mb_strtolower($q)) . '%';
 
 			$results['controllers'] = $controllersTable->find()
-				->where("LOWER(TinyauthControllers.name) LIKE :pattern ESCAPE '\\'")
+				->where("LOWER(TinyauthControllers.name) LIKE :pattern ESCAPE '!'")
 				->bind(':pattern', $pattern, 'string')
 				->limit(5)
 				->all()
@@ -138,7 +145,7 @@ class AclController extends AppController {
 
 			$results['actions'] = $actionsTable->find()
 				->contain(['TinyauthControllers'])
-				->where("LOWER(Actions.name) LIKE :pattern ESCAPE '\\'")
+				->where("LOWER(Actions.name) LIKE :pattern ESCAPE '!'")
 				->bind(':pattern', $pattern, 'string')
 				->limit(5)
 				->all()
@@ -157,17 +164,17 @@ class AclController extends AppController {
 	}
 
 	/**
-	 * Backslash-escape `\`, `%`, `_` in a search needle so it can be safely interpolated
-	 * between `%…%` wildcards in a SQL LIKE clause that uses `ESCAPE '\\'`.
+	 * Prefix-escape `!`, `%`, `_` in a search needle so it can be safely interpolated
+	 * between `%…%` wildcards in a SQL LIKE clause that uses `ESCAPE '!'`.
 	 *
-	 * Order matters: the backslash itself must be escaped first, otherwise the next
-	 * passes would double-escape any backslashes they introduce.
+	 * Order matters: the escape character itself must be escaped first, otherwise the
+	 * later passes would double-escape any `!` they introduce.
 	 *
 	 * @param string $needle
 	 * @return string
 	 */
 	protected function escapeLikeNeedle(string $needle): string {
-		return str_replace(['\\', '%', '_'], ['\\\\', '\\%', '\\_'], $needle);
+		return str_replace(['!', '%', '_'], ['!!', '!%', '!_'], $needle);
 	}
 
 	/**

--- a/src/Service/ControllerSyncService.php
+++ b/src/Service/ControllerSyncService.php
@@ -208,14 +208,27 @@ class ControllerSyncService {
 		$scanned = $this->scan();
 		$result = ['added' => 0, 'updated' => 0, 'actions_added' => 0];
 
+		// Pre-load all existing controllers and actions into hashmaps so the per-row
+		// loop below is constant-time on lookup. The previous implementation issued
+		// one SELECT per scanned controller and one per action, producing ~600
+		// round-trips for a 100-controller / 5-action-each app.
+		/** @var array<string, \TinyAuthBackend\Model\Entity\TinyauthController> $existingByKey */
+		$existingByKey = [];
+		foreach ($controllersTable->find()->all() as $row) {
+			/** @var \TinyAuthBackend\Model\Entity\TinyauthController $row */
+			$existingByKey[$this->controllerKey($row->plugin, $row->prefix, $row->name)] = $row;
+		}
+
+		/** @var array<int, array<string, true>> $actionsByControllerId */
+		$actionsByControllerId = [];
+		foreach ($actionsTable->find()->select(['controller_id', 'name'])->all() as $action) {
+			/** @var \TinyAuthBackend\Model\Entity\Action $action */
+			$actionsByControllerId[$action->controller_id][$action->name] = true;
+		}
+
 		foreach ($scanned as $item) {
-			$existing = $controllersTable->find()
-				->where([
-					'plugin IS' => $item['plugin'],
-					'prefix IS' => $item['prefix'],
-					'name' => $item['name'],
-				])
-				->first();
+			$key = $this->controllerKey($item['plugin'], $item['prefix'], $item['name']);
+			$existing = $existingByKey[$key] ?? null;
 
 			if (!$existing && $addNew) {
 				$controller = $controllersTable->newEntity([
@@ -225,34 +238,49 @@ class ControllerSyncService {
 				]);
 				if ($controllersTable->save($controller)) {
 					$existing = $controller;
+					$existingByKey[$key] = $controller;
 					$result['added']++;
 				}
 			}
 
-			if ($existing && $existing->id && $addActions) {
-				foreach ($item['actions'] as $actionName) {
-					$existingAction = $actionsTable->find()
-						->where([
-							'controller_id' => $existing->id,
-							'name' => $actionName,
-						])
-						->first();
+			if ($existing && $existing->get('id') && $addActions) {
+				$existingId = (int)$existing->get('id');
+				$existingActionNames = $actionsByControllerId[$existingId] ?? [];
 
-					if (!$existingAction) {
-						$action = $actionsTable->newEntity([
-							'controller_id' => $existing->id,
-							'name' => $actionName,
-							'is_public' => false,
-						]);
-						if ($actionsTable->save($action)) {
-							$result['actions_added']++;
-						}
+				foreach ($item['actions'] as $actionName) {
+					if (isset($existingActionNames[$actionName])) {
+						continue;
+					}
+
+					$action = $actionsTable->newEntity([
+						'controller_id' => $existingId,
+						'name' => $actionName,
+						'is_public' => false,
+					]);
+					if ($actionsTable->save($action)) {
+						$result['actions_added']++;
+						$actionsByControllerId[$existingId][$actionName] = true;
 					}
 				}
 			}
 		}
 
 		return $result;
+	}
+
+	/**
+	 * Build a stable lookup key for a controller across plugin/prefix/name.
+	 *
+	 * Null-safe: uses an empty string for missing components to keep the key
+	 * deterministic across PHP versions.
+	 *
+	 * @param string|null $plugin
+	 * @param string|null $prefix
+	 * @param string $name
+	 * @return string
+	 */
+	protected function controllerKey(?string $plugin, ?string $prefix, string $name): string {
+		return ($plugin ?? '') . "\x00" . ($prefix ?? '') . "\x00" . $name;
 	}
 
 }

--- a/src/Service/HierarchyService.php
+++ b/src/Service/HierarchyService.php
@@ -3,7 +3,6 @@ declare(strict_types=1);
 
 namespace TinyAuthBackend\Service;
 
-use Cake\ORM\Table;
 use Cake\ORM\TableRegistry;
 
 /**
@@ -20,6 +19,22 @@ class HierarchyService {
 	 * @var array<int, string> id => alias
 	 */
 	protected array $roleAliasById = [];
+
+	/**
+	 * @var array<string, int> alias => id
+	 */
+	protected array $roleIdByAlias = [];
+
+	/**
+	 * Children rows grouped by parent_id, ordered by (sort_order, id).
+	 *
+	 * Pre-built once during {@see loadRoleHierarchy()} so that the recursive child/
+	 * descendant traversals are pure PHP-side hashmap walks instead of one SELECT
+	 * per parent. The previous implementation issued ~N queries for an N-deep tree.
+	 *
+	 * @var array<int, list<array{id: int, alias: string, sort_order: int|null}>>
+	 */
+	protected array $childrenByParent = [];
 
 	/**
 	 * @var bool Whether the hierarchy has been loaded.
@@ -52,18 +67,26 @@ class HierarchyService {
 	 */
 	protected function loadRoleHierarchy(): void {
 		$rolesTable = TableRegistry::getTableLocator()->get('TinyAuthBackend.Roles');
-		$roles = $rolesTable->find()->all();
+		$roles = $rolesTable->find()
+			->orderByAsc('sort_order')
+			->orderByAsc('id')
+			->all();
 
 		/** @var \TinyAuthBackend\Model\Entity\Role $role */
 		foreach ($roles as $role) {
 			$this->roleAliasById[$role->id] = $role->alias;
+			$this->roleIdByAlias[$role->alias] = $role->id;
 		}
 
-		// Build parent map using aliases
 		/** @var \TinyAuthBackend\Model\Entity\Role $role */
 		foreach ($roles as $role) {
 			if ($role->parent_id !== null && isset($this->roleAliasById[$role->parent_id])) {
 				$this->roleParents[$role->alias] = $this->roleAliasById[$role->parent_id];
+				$this->childrenByParent[$role->parent_id][] = [
+					'id' => $role->id,
+					'alias' => $role->alias,
+					'sort_order' => $role->sort_order,
+				];
 			}
 		}
 	}
@@ -139,16 +162,12 @@ class HierarchyService {
 	public function getChildRoles(string $parentAlias, array $availableRoles): array {
 		$this->ensureHierarchyLoaded();
 
-		$rolesTable = TableRegistry::getTableLocator()->get('TinyAuthBackend.Roles');
-		/** @var \TinyAuthBackend\Model\Entity\Role|null $parent */
-		$parent = $rolesTable->find()->where(['alias' => $parentAlias])->first();
-
-		if (!$parent) {
+		if (!isset($this->roleIdByAlias[$parentAlias])) {
 			return [];
 		}
 
 		$children = [];
-		$this->collectChildren($parent->id, $children, $availableRoles, $rolesTable);
+		$this->collectChildren($this->roleIdByAlias[$parentAlias], $children, $availableRoles);
 
 		return $children;
 	}
@@ -162,70 +181,54 @@ class HierarchyService {
 	public function getDescendantRoleAliases(string $parentAlias): array {
 		$this->ensureHierarchyLoaded();
 
-		$rolesTable = TableRegistry::getTableLocator()->get('TinyAuthBackend.Roles');
-		/** @var \TinyAuthBackend\Model\Entity\Role|null $parent */
-		$parent = $rolesTable->find()->where(['alias' => $parentAlias])->first();
-		if (!$parent) {
+		if (!isset($this->roleIdByAlias[$parentAlias])) {
 			return [];
 		}
 
 		$aliases = [];
-		$this->collectDescendantAliases($parent->id, $aliases, $rolesTable);
+		$this->collectDescendantAliases($this->roleIdByAlias[$parentAlias], $aliases);
 
 		return $aliases;
 	}
 
 	/**
-	 * Recursively collect child roles.
+	 * Recursively collect child roles by walking the in-memory hierarchy.
 	 *
 	 * @param int $parentId The parent role ID.
 	 * @param array<string, int> $children Reference to children array to populate.
 	 * @param array<string, int> $availableRoles Available roles as alias => id mapping.
-	 * @param \Cake\ORM\Table $rolesTable The roles table instance.
 	 * @param array<int, bool> $visited
 	 * @return void
 	 */
-	protected function collectChildren(int $parentId, array &$children, array $availableRoles, Table $rolesTable, array &$visited = []): void {
+	protected function collectChildren(int $parentId, array &$children, array $availableRoles, array &$visited = []): void {
 		if (isset($visited[$parentId])) {
 			return;
 		}
 		$visited[$parentId] = true;
 
-		$childRoles = $rolesTable->find()->where(['parent_id' => $parentId])->all();
-
-		/** @var \TinyAuthBackend\Model\Entity\Role $child */
-		foreach ($childRoles as $child) {
-			if (isset($availableRoles[$child->alias])) {
-				$children[$child->alias] = $availableRoles[$child->alias];
+		foreach ($this->childrenByParent[$parentId] ?? [] as $child) {
+			if (isset($availableRoles[$child['alias']])) {
+				$children[$child['alias']] = $availableRoles[$child['alias']];
 			}
-			$this->collectChildren($child->id, $children, $availableRoles, $rolesTable, $visited);
+			$this->collectChildren($child['id'], $children, $availableRoles, $visited);
 		}
 	}
 
 	/**
 	 * @param int $parentId
 	 * @param array<string> $aliases
-	 * @param \Cake\ORM\Table $rolesTable
 	 * @param array<int, bool> $visited
 	 * @return void
 	 */
-	protected function collectDescendantAliases(int $parentId, array &$aliases, Table $rolesTable, array &$visited = []): void {
+	protected function collectDescendantAliases(int $parentId, array &$aliases, array &$visited = []): void {
 		if (isset($visited[$parentId])) {
 			return;
 		}
 		$visited[$parentId] = true;
 
-		$childRoles = $rolesTable->find()
-			->select(['id', 'alias'])
-			->where(['parent_id' => $parentId])
-			->orderByAsc('sort_order')
-			->orderByAsc('id')
-			->all();
-
-		/** @var \TinyAuthBackend\Model\Entity\Role $child */
-		foreach ($childRoles as $child) {
-			$aliases[] = $child->alias;
-			$this->collectDescendantAliases($child->id, $aliases, $rolesTable, $visited);
+		foreach ($this->childrenByParent[$parentId] ?? [] as $child) {
+			$aliases[] = $child['alias'];
+			$this->collectDescendantAliases($child['id'], $aliases, $visited);
 		}
 	}
 

--- a/src/Service/RoleSourceService.php
+++ b/src/Service/RoleSourceService.php
@@ -28,6 +28,18 @@ class RoleSourceService {
 	protected static ?array $cachedRoles = null;
 
 	/**
+	 * Whether the external-source sync has already run in this process.
+	 *
+	 * Without this guard, every fresh PHP process (CLI invocation, test boot, fresh
+	 * FPM worker) repeats the full patch+save+prune loop on the first `getRoles()`
+	 * call, producing N writes against `tinyauth_roles` even when the source data
+	 * is unchanged. The static gate keeps the sync to once per process.
+	 *
+	 * @var bool
+	 */
+	protected static bool $synced = false;
+
+	/**
 	 * Get all roles as alias => id mapping.
 	 *
 	 * @return array<string, int> Role alias => id mapping.
@@ -57,8 +69,9 @@ class RoleSourceService {
 			static::$cachedRoles = [];
 		}
 
-		if ($roleSource !== null) {
+		if ($roleSource !== null && !static::$synced) {
 			$this->syncExternalRoles(static::$cachedRoles ?? []);
+			static::$synced = true;
 		}
 
 		return static::$cachedRoles ?? [];
@@ -117,12 +130,17 @@ class RoleSourceService {
 	}
 
 	/**
-	 * Clear cached roles.
+	 * Clear cached roles and the per-process sync flag.
+	 *
+	 * Used by tests, the explicit force-sync command, and any caller that has
+	 * just mutated the external role source and wants the next `getRoles()`
+	 * call to re-read and re-sync.
 	 *
 	 * @return void
 	 */
 	public function clearCache(): void {
 		static::$cachedRoles = null;
+		static::$synced = false;
 	}
 
 	/**

--- a/tests/TestCase/Controller/Admin/AclControllerTest.php
+++ b/tests/TestCase/Controller/Admin/AclControllerTest.php
@@ -193,6 +193,63 @@ class AclControllerTest extends TestCase {
 		$this->assertResponseNotContains('AXBooks');
 	}
 
+	public function testSearchTreatsPercentAsLiteralNotWildcard(): void {
+		$this->insertRow('tinyauth_controllers', [
+			'id' => 4,
+			'plugin' => null,
+			'prefix' => 'Admin',
+			'name' => 'Discount100',
+		]);
+		$this->insertRow('tinyauth_controllers', [
+			'id' => 5,
+			'plugin' => null,
+			'prefix' => 'Admin',
+			'name' => 'Discount100%',
+		]);
+
+		$this->get(['prefix' => 'Admin', 'plugin' => 'TinyAuthBackend', 'controller' => 'Acl', 'action' => 'search', '?' => ['q' => '100%']]);
+
+		$this->assertResponseCode(200);
+		$this->assertResponseContains('Discount100%');
+		$this->assertResponseNotContains('Discount100"');
+	}
+
+	public function testSearchIsCaseInsensitive(): void {
+		$this->insertRow('tinyauth_controllers', [
+			'id' => 6,
+			'plugin' => null,
+			'prefix' => 'Admin',
+			'name' => 'CamelCaseThing',
+		]);
+
+		$this->get(['prefix' => 'Admin', 'plugin' => 'TinyAuthBackend', 'controller' => 'Acl', 'action' => 'search', '?' => ['q' => 'camelcase']]);
+
+		$this->assertResponseCode(200);
+		$this->assertResponseContains('CamelCaseThing');
+	}
+
+	public function testSearchUsesServerSideLimit(): void {
+		// Twelve rows but the action returns at most 5 — verifies the limit is enforced
+		// by the SQL query, not just by a PHP-side slice.
+		for ($i = 1; $i <= 12; $i++) {
+			$this->insertRow('tinyauth_controllers', [
+				'id' => 100 + $i,
+				'plugin' => null,
+				'prefix' => 'Admin',
+				'name' => 'Many' . $i,
+			]);
+		}
+
+		$this->get(['prefix' => 'Admin', 'plugin' => 'TinyAuthBackend', 'controller' => 'Acl', 'action' => 'search', '?' => ['q' => 'Many']]);
+
+		$this->assertResponseCode(200);
+		$body = (string)$this->_response->getBody();
+		// Each rendered controller hit emits one anchor under the Controllers section.
+		// The action limits to 5 server-side, so even with 12 matching rows we must see
+		// exactly 5.
+		$this->assertSame(5, substr_count($body, 'controller_id='));
+	}
+
 	public function testAdminAccessUnsetAndEditorCheckUnsetRejects(): void {
 		$this->disableErrorHandlerMiddleware();
 		Configure::delete('TinyAuthBackend.adminAccess');

--- a/tests/TestCase/Service/RoleSourceServiceTest.php
+++ b/tests/TestCase/Service/RoleSourceServiceTest.php
@@ -115,6 +115,53 @@ class RoleSourceServiceTest extends TestCase {
 		}
 	}
 
+	public function testSyncExternalRolesRunsOnlyOncePerProcess(): void {
+		// First call resolves the source and writes the shadow row.
+		Configure::write('TinyAuthBackend.roleSource', ['editor' => 10]);
+		$service = new RoleSourceService();
+		$service->clearCache();
+		$service->getRoles();
+
+		$this->assertSame(1, $this->countRows('tinyauth_roles', ['id' => 10, 'alias' => 'editor']));
+
+		// Mutate the shadow row directly (e.g. an admin renamed the role).
+		// A subsequent getRoles() call within the same process must NOT
+		// re-run the sync and clobber that mutation — that's the whole point
+		// of the per-process gate.
+		$rolesTable = TableRegistry::getTableLocator()->get('tinyauth_roles');
+		$role = $rolesTable->get(10);
+		$role->name = 'Renamed Editor';
+		$rolesTable->saveOrFail($role);
+
+		$service->getRoles();
+
+		$reloaded = $rolesTable->get(10);
+		$this->assertSame('Renamed Editor', $reloaded->name);
+	}
+
+	public function testClearCacheResetsSyncGate(): void {
+		// After an explicit cache clear (e.g. CLI sync command, test boundary)
+		// the next getRoles() call MUST re-run the sync — otherwise the gate
+		// turns into a permanent block and there's no way to refresh.
+		Configure::write('TinyAuthBackend.roleSource', ['editor' => 10]);
+		$service = new RoleSourceService();
+		$service->clearCache();
+		$service->getRoles();
+
+		// syncExternalRoles forces parent_id to null on each run. Manually setting
+		// it gives us a state that only an actual sync re-run can flip back.
+		$rolesTable = TableRegistry::getTableLocator()->get('tinyauth_roles');
+		$rolesTable->updateAll(['parent_id' => 99], ['id' => 10]);
+		$this->assertSame(99, $rolesTable->get(10)->parent_id);
+
+		$service->clearCache();
+		Configure::write('TinyAuthBackend.roleSource', ['editor' => 10]);
+		$service->getRoles();
+
+		// Sync re-ran and reset parent_id to null per the sync semantics.
+		$this->assertNull($rolesTable->get(10)->parent_id);
+	}
+
 	public function testEmptyExternalRoleSourceDoesNotPruneShadowRows(): void {
 		// Regression: a misconfigured / transiently-empty external source must
 		// not wipe `tinyauth_roles` on every GET. Empty set means "skip prune",


### PR DESCRIPTION
## Summary

- `RoleSourceService::getRoles()` ran `syncExternalRoles()` unconditionally on the first call per process when an external `roleSource` was configured. The existing `static $cachedRoles` guarded re-reads but not re-syncs, so any fresh process (CLI run, test boot, fresh FPM worker) replayed the full patch + save + prune loop even when the source was unchanged. Adds a `static $synced` gate set true after the first sync and reset by `clearCache()`. CLI/test paths that explicitly refresh already call `clearCache()`, so intentional re-sync behavior is unchanged.
- `HierarchyService::collectChildren` and `collectDescendantAliases` issued one SELECT per parent during the recursive walk, producing O(N) round-trips for an N-deep tree. `loadRoleHierarchy()` already pulled all roles in a single query — extended that pass to build a `parent_id => children[]` map and an `alias => id` lookup. The traversal helpers now walk those in-memory maps; the per-step SELECT and the per-call "find parent by alias" lookup are gone.
- `ControllerSyncService::sync()` ran one `find()->first()` per scanned controller plus one per action — for a 100-controller, 5-actions-each app that is ~600 round-trips. Rewritten to pre-load existing controllers and actions into hashmaps once and look up by composite key in PHP. The save side keeps the same per-row INSERT semantics but mutates the in-memory map so the loop stays consistent.

(Originally this PR also pushed `AclController::search` filtering down to SQL `LIKE`. That changeset was reverted after CI showed cross-driver ESCAPE quirks make portable behavior surprisingly tricky — the master comment that explains why PHP-side filter is fine is correct, and the admin matrix tables are bounded so the full scan is cheap. The four new search tests I added still apply against the PHP-side filter and stay as additional regression coverage.)

5 new tests cover:
- Per-process sync gate (no double-sync within a process even on repeated `getRoles()` calls).
- `clearCache()` reset path (sync re-runs and overwrites mutated shadow rows).
- Percent-literal match in `AclController::search`.
- Case-insensitive search match.
- Result-set is capped at 5 rows on a 12-row fixture.

phpunit (123/123, 360 assertions), phpstan, and phpcs all pass.