### PR TITLE
Match foreign key signedness to Migrations.unsigned_primary_keys

### DIFF
--- a/config/Migrations/20260325000000_CreateTinyAuthTables.php
+++ b/config/Migrations/20260325000000_CreateTinyAuthTables.php
@@ -14,8 +14,9 @@ class CreateTinyAuthTables extends BaseMigration {
 		// reference. The auto-increment `id` columns follow the
 		// `Migrations.unsigned_primary_keys` flag, so the foreign keys must too;
 		// otherwise addForeignKey() fails on MySQL (errno 150) for unsigned-key apps.
-		// Defaults to signed; only MySQL honors signedness.
-		$signed = !(bool)Configure::read('Migrations.unsigned_primary_keys');
+		// The flag is false (signed) when unset; pass the default explicitly to
+		// make that intent unmistakable. Only MySQL honors signedness.
+		$signed = !(bool)Configure::read('Migrations.unsigned_primary_keys', false);
 
 		// Drop legacy 2.x tables from previous versions
 		if ($this->hasTable('tiny_auth_acl_rules')) {

--- a/config/Migrations/20260325000000_CreateTinyAuthTables.php
+++ b/config/Migrations/20260325000000_CreateTinyAuthTables.php
@@ -1,6 +1,7 @@
 <?php
 declare(strict_types=1);
 
+use Cake\Core\Configure;
 use Migrations\BaseMigration;
 
 class CreateTinyAuthTables extends BaseMigration {
@@ -9,6 +10,13 @@ class CreateTinyAuthTables extends BaseMigration {
 	 * @return void
 	 */
 	public function change(): void {
+		// Foreign key columns must match the signedness of the primary keys they
+		// reference. The auto-increment `id` columns follow the
+		// `Migrations.unsigned_primary_keys` flag, so the foreign keys must too;
+		// otherwise addForeignKey() fails on MySQL (errno 150) for unsigned-key apps.
+		// Defaults to signed; only MySQL honors signedness.
+		$signed = !(bool)Configure::read('Migrations.unsigned_primary_keys');
+
 		// Drop legacy 2.x tables from previous versions
 		if ($this->hasTable('tiny_auth_acl_rules')) {
 			$this->table('tiny_auth_acl_rules')->drop()->save();
@@ -21,7 +29,7 @@ class CreateTinyAuthTables extends BaseMigration {
 		$this->table('tinyauth_roles')
 			->addColumn('name', 'string', ['limit' => 100, 'null' => false])
 			->addColumn('alias', 'string', ['limit' => 50, 'null' => false])
-			->addColumn('parent_id', 'integer', ['null' => true, 'default' => null])
+			->addColumn('parent_id', 'integer', ['null' => true, 'default' => null, 'signed' => $signed])
 			->addColumn('sort_order', 'integer', ['default' => 0])
 			->addColumn('created', 'datetime', ['null' => true])
 			->addColumn('modified', 'datetime', ['null' => true])
@@ -49,7 +57,7 @@ class CreateTinyAuthTables extends BaseMigration {
 
 		// Actions table
 		$this->table('tinyauth_actions')
-			->addColumn('controller_id', 'integer', ['null' => false])
+			->addColumn('controller_id', 'integer', ['null' => false, 'signed' => $signed])
 			->addColumn('name', 'string', ['limit' => 100, 'null' => false])
 			->addColumn('is_public', 'boolean', ['default' => false])
 			->addColumn('created', 'datetime', ['null' => true])
@@ -63,8 +71,8 @@ class CreateTinyAuthTables extends BaseMigration {
 
 		// ACL Permissions table
 		$this->table('tinyauth_acl_permissions')
-			->addColumn('action_id', 'integer', ['null' => false])
-			->addColumn('role_id', 'integer', ['null' => false])
+			->addColumn('action_id', 'integer', ['null' => false, 'signed' => $signed])
+			->addColumn('role_id', 'integer', ['null' => false, 'signed' => $signed])
 			->addColumn('type', 'string', ['limit' => 10, 'default' => 'allow'])
 			->addColumn('created', 'datetime', ['null' => true])
 			->addColumn('modified', 'datetime', ['null' => true])
@@ -91,7 +99,7 @@ class CreateTinyAuthTables extends BaseMigration {
 
 		// Resource Abilities table
 		$this->table('tinyauth_resource_abilities')
-			->addColumn('resource_id', 'integer', ['null' => false])
+			->addColumn('resource_id', 'integer', ['null' => false, 'signed' => $signed])
 			->addColumn('name', 'string', ['limit' => 50, 'null' => false])
 			->addColumn('description', 'string', ['limit' => 200, 'null' => true])
 			->addColumn('created', 'datetime', ['null' => true])
@@ -116,10 +124,10 @@ class CreateTinyAuthTables extends BaseMigration {
 
 		// Resource ACL table
 		$this->table('tinyauth_resource_acl')
-			->addColumn('resource_ability_id', 'integer', ['null' => false])
-			->addColumn('role_id', 'integer', ['null' => false])
+			->addColumn('resource_ability_id', 'integer', ['null' => false, 'signed' => $signed])
+			->addColumn('role_id', 'integer', ['null' => false, 'signed' => $signed])
 			->addColumn('type', 'string', ['limit' => 10, 'default' => 'allow'])
-			->addColumn('scope_id', 'integer', ['null' => true])
+			->addColumn('scope_id', 'integer', ['null' => true, 'signed' => $signed])
 			->addColumn('created', 'datetime', ['null' => true])
 			->addColumn('modified', 'datetime', ['null' => true])
 			->addIndex(['resource_ability_id', 'role_id'], ['unique' => true])


### PR DESCRIPTION
## Problem

The integer foreign key columns in `CreateTinyAuthTables` (`parent_id`, `controller_id`, `action_id`, `role_id`, `resource_id`, `resource_ability_id`, `scope_id`) are created with the default signedness (signed). Each table's auto-increment `id`, however, follows the `Migrations.unsigned_primary_keys` flag.

On an app configured with unsigned primary keys, `addForeignKey()` then fails on MySQL with **errno 150** ("Foreign key constraint is incorrectly formed") because the foreign key column type does not match the referenced primary key. The tables can never be created on such an app.

## Fix

Derive the signedness from the same flag so the foreign keys always match the referenced primary keys:

```php
$signed = !(bool)Configure::read('Migrations.unsigned_primary_keys');
```

This edits the released create migration on purpose. A follow-up migration cannot repair the failure, because on the affected apps the tables are never created in the first place — there is nothing to alter. For signed-primary-key apps (the Migrations default) and for SQLite the resulting schema is identical to before, so existing installs are unaffected.
