### PR TITLE
Fix PHPStan on CakePHP 5.4

### DIFF
--- a/src/TinyAuthBackendPlugin.php
+++ b/src/TinyAuthBackendPlugin.php
@@ -5,7 +5,9 @@ namespace TinyAuthBackend;
 
 use Cake\Console\CommandCollection;
 use Cake\Core\BasePlugin;
+use Cake\Core\PluginApplicationInterface;
 use Cake\Routing\RouteBuilder;
+use InvalidArgumentException;
 use TinyAuthBackend\Command\ImportCommand;
 use TinyAuthBackend\Command\InitCommand;
 use TinyAuthBackend\Command\SyncCommand;
@@ -31,10 +33,14 @@ class TinyAuthBackendPlugin extends BasePlugin {
 	protected bool $routesEnabled = true;
 
 	/**
-	 * @param \Cake\Core\PluginApplicationInterface $app The application instance
+	 * @param mixed $app The application instance
 	 * @return void
 	 */
-	public function bootstrap($app): void {
+	public function bootstrap(mixed $app): void {
+		if (!$app instanceof PluginApplicationInterface) {
+			throw new InvalidArgumentException('Expected a plugin application instance.');
+		}
+
 		parent::bootstrap($app);
 	}
 

--- a/src/TinyAuthBackendPlugin.php
+++ b/src/TinyAuthBackendPlugin.php
@@ -32,7 +32,7 @@ class TinyAuthBackendPlugin extends BasePlugin {
 	protected bool $routesEnabled = true;
 
 	/**
-	 * @param \Cake\Core\PluginApplicationInterface<\Cake\Core\HttpApplicationInterface> $app The application instance
+	 * @param \Cake\Core\PluginApplicationInterface $app The application instance
 	 * @return void
 	 */
 	public function bootstrap(PluginApplicationInterface $app): void {

--- a/src/TinyAuthBackendPlugin.php
+++ b/src/TinyAuthBackendPlugin.php
@@ -5,7 +5,6 @@ namespace TinyAuthBackend;
 
 use Cake\Console\CommandCollection;
 use Cake\Core\BasePlugin;
-use Cake\Core\PluginApplicationInterface;
 use Cake\Routing\RouteBuilder;
 use TinyAuthBackend\Command\ImportCommand;
 use TinyAuthBackend\Command\InitCommand;
@@ -35,7 +34,7 @@ class TinyAuthBackendPlugin extends BasePlugin {
 	 * @param \Cake\Core\PluginApplicationInterface $app The application instance
 	 * @return void
 	 */
-	public function bootstrap(PluginApplicationInterface $app): void {
+	public function bootstrap($app): void {
 		parent::bootstrap($app);
 	}
 


### PR DESCRIPTION
Fixes PHPStan findings surfaced with CakePHP 5.4.0-RC2.\n\nVerified locally with CakePHP 5.4.0-RC2:\n- composer stan\n- composer cs-check\n- composer test